### PR TITLE
build: add rust-analyzer to nix environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,8 +35,6 @@
           pkgs.just
           # Run Github actions locally
           pkgs.act
-          # Rust Analyzer binary
-          pkgs.rust-analyzer
         ];
       in
       {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,6 +6,6 @@
 # but we use the oxalica overlay, which does not fix this yet.
 # Should be fixed by https://github.com/rust-lang/rust/issues/123151.
 channel = "1.82.0"
-components = ["clippy", "rustfmt", "rust-src"]
+components = ["clippy", "rustfmt", "rust-src", "rust-analyzer"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
## Description

It was using the system-wide installation and making it significantly slower

## Related Issues

It had to rebuild every time you jump into polkadot code with the system wide instalation which is slower compared to the nix's.