### PR TITLE
chore(emission0): test emissions

### DIFF
--- a/pallets/emission0/src/distribute.rs
+++ b/pallets/emission0/src/distribute.rs
@@ -8,16 +8,16 @@ use polkadot_sdk::{
     },
     polkadot_sdk_frame::prelude::BlockNumberFor,
     sp_core::Get,
-    sp_runtime::{ArithmeticError, DispatchError},
+    sp_runtime::{traits::Saturating, ArithmeticError, DispatchError, Perquintill},
     sp_std::{
         borrow::Cow,
         collections::{btree_map::BTreeMap, btree_set::BTreeSet},
         vec,
         vec::Vec,
     },
-    sp_tracing::{error, info, warn},
+    sp_tracing::{error, info},
 };
-use substrate_fixed::{traits::FromFixed, types::I96F32};
+use substrate_fixed::types::I96F32;
 
 use crate::{BalanceOf, Config, ConsensusMember};
 
@@ -81,8 +81,8 @@ pub struct ConsensusMemberInput<T: Config> {
     pub agent_id: T::AccountId,
     pub validator_permit: bool,
     pub weights: Vec<(T::AccountId, I96F32)>,
-    pub stakes: Vec<(T::AccountId, I96F32)>,
-    pub total_stake: I96F32,
+    pub stakes: Vec<(T::AccountId, u128)>,
+    pub total_stake: u128,
     pub normalized_stake: I96F32,
     pub delegating_to: Option<T::AccountId>,
     pub registered: bool,
@@ -143,7 +143,8 @@ impl<T: Config> ConsensusMemberInput<T> {
             (agent_id, input)
         }));
 
-        let total_network_stake: I96F32 = inputs.iter().map(|(_, member)| member.total_stake).sum();
+        let total_network_stake: I96F32 =
+            I96F32::from_num::<u128>(inputs.iter().map(|(_, member)| member.total_stake).sum());
 
         inputs.sort_unstable_by(|(_, a), (_, b)| {
             b.validator_permit
@@ -159,7 +160,8 @@ impl<T: Config> ConsensusMemberInput<T> {
             }
 
             if total_network_stake != I96F32::from_num(0) {
-                input.normalized_stake = input.total_stake.saturating_div(total_network_stake)
+                input.normalized_stake =
+                    I96F32::from_num(input.total_stake).saturating_div(total_network_stake)
             }
         }
 
@@ -174,11 +176,10 @@ impl<T: Config> ConsensusMemberInput<T> {
         member: ConsensusMember<T>,
         min_allowed_stake: u128,
     ) -> ConsensusMemberInput<T> {
-        let mut total_stake = I96F32::default();
+        let mut total_stake = 0;
         let stakes = <T::Torus>::staked_by(&agent_id)
             .into_iter()
             .map(|(id, stake)| {
-                let stake = I96F32::from_num(stake);
                 total_stake = total_stake.saturating_add(stake);
                 (id, stake)
             })
@@ -234,20 +235,11 @@ impl<T: Config> ConsensusMemberInput<T> {
     }
 
     /// Normalizes the list of stakers to the agent, and adds the agent itself in case no stake was given.
-    pub fn normalized_stakers(&self) -> Vec<(T::AccountId, I96F32)> {
-        if self.total_stake == I96F32::default() {
-            vec![(self.agent_id.clone(), I96F32::default())]
-        } else {
-            self.stakes
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        k.clone(),
-                        v.checked_div(self.total_stake).unwrap_or_default(),
-                    )
-                })
-                .collect()
-        }
+    pub fn normalized_stakers(&self) -> Vec<(T::AccountId, Perquintill)> {
+        self.stakes
+            .iter()
+            .map(|(k, v)| (k.clone(), Perquintill::from_rational(*v, self.total_stake)))
+            .collect()
     }
 }
 
@@ -293,7 +285,7 @@ fn linear_rewards<T: Config>(
             .values()
             .map(|input| {
                 if input.validator_permit {
-                    input.total_stake
+                    I96F32::from_num(input.total_stake)
                 } else {
                     I96F32::default()
                 }
@@ -338,26 +330,14 @@ fn linear_rewards<T: Config>(
                 T::Currency::resolve_creating(delegating_to, stake);
             }
 
-            let fixed_dividend = I96F32::from_num(dividend.peek());
+            let fixed_dividend = dividend.peek();
 
             let stakers = input.normalized_stakers();
             let delegation_fee = <T::Torus>::staking_fee(&input.agent_id);
             for (staker, ratio) in stakers {
-                if staker == input.agent_id {
-                    continue;
-                }
-
-                let Some(staker_dividend) = fixed_dividend.checked_mul(ratio).map(u128::from_fixed)
-                else {
-                    warn!(
-                        "failed to calculate dividend for {:?} on {:?}",
-                        staker, input.agent_id
-                    );
-
-                    continue;
-                };
-
+                let staker_dividend = ratio.mul_floor(fixed_dividend);
                 let stake_fee = delegation_fee.mul_floor(staker_dividend);
+
                 let stake = dividend.extract(staker_dividend.saturating_sub(stake_fee));
 
                 add_stake(staker, stake);

--- a/pallets/emission0/src/weights.rs
+++ b/pallets/emission0/src/weights.rs
@@ -12,13 +12,31 @@ use crate::{ConsensusMember, ConsensusMembers};
 
 pub fn set_weights<T: crate::Config>(
     origin: OriginFor<T>,
-    weights: sp_std::vec::Vec<(T::AccountId, u16)>,
+    mut weights: sp_std::vec::Vec<(T::AccountId, u16)>,
 ) -> DispatchResult {
     let acc_id = ensure_signed(origin)?;
 
     ensure!(
         weights.len() <= crate::MaxAllowedWeights::<T>::get() as usize,
         crate::Error::<T>::WeightSetTooLarge
+    );
+
+    ensure!(
+        <T::Torus>::is_agent_registered(&acc_id),
+        crate::Error::<T>::AgentIsNotRegistered
+    );
+
+    let total_stake: u128 = <T::Torus>::staked_by(&acc_id)
+        .iter()
+        .map(|(_, stake)| *stake)
+        .sum();
+    let min_stake_for_weights = crate::MinStakePerWeight::<T>::get()
+        .checked_mul(weights.len() as u128)
+        .unwrap_or_default();
+
+    ensure!(
+        total_stake >= min_stake_for_weights,
+        crate::Error::<T>::NotEnoughStakeToSetWeights
     );
 
     for (target, _) in &weights {
@@ -29,17 +47,22 @@ pub fn set_weights<T: crate::Config>(
 
         ensure!(
             <T::Torus>::is_agent_registered(target),
-            crate::Error::<T>::AgentDoesNotExist
+            crate::Error::<T>::AgentIsNotRegistered
         );
     }
+
+    weights.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
+    weights.dedup();
 
     let weights: BoundedVec<_, ConstU32<{ u32::MAX }>> =
         BoundedVec::try_from(weights).map_err(|_| crate::Error::<T>::WeightSetTooLarge)?;
 
-    ConsensusMembers::<T>::mutate(acc_id, |member: &mut Option<ConsensusMember<T>>| {
+    ConsensusMembers::<T>::mutate(&acc_id, |member: &mut Option<ConsensusMember<T>>| {
         let member = member.get_or_insert_with(Default::default);
         member.update_weights(weights);
     });
+
+    crate::Pallet::<T>::deposit_event(crate::Event::<T>::WeightsSet(acc_id));
 
     Ok(())
 }
@@ -49,12 +72,34 @@ pub fn delegate_weight_control<T: crate::Config>(
     target: T::AccountId,
 ) -> DispatchResult {
     let acc_id = ensure_signed(origin)?;
-    crate::WeightControlDelegation::<T>::set(acc_id, Some(target));
+
+    ensure!(
+        acc_id != target,
+        crate::Error::<T>::CannotDelegateWeightControlToSelf,
+    );
+
+    ensure!(
+        <T::Torus>::is_agent_registered(&acc_id),
+        crate::Error::<T>::AgentIsNotRegistered
+    );
+
+    ensure!(
+        <T::Torus>::is_agent_registered(&target),
+        crate::Error::<T>::AgentIsNotRegistered
+    );
+
+    crate::WeightControlDelegation::<T>::set(&acc_id, Some(target.clone()));
+
+    crate::Pallet::<T>::deposit_event(crate::Event::<T>::DelegatedWeightControl(acc_id, target));
+
     Ok(())
 }
 
 pub fn regain_weight_control<T: crate::Config>(origin: OriginFor<T>) -> DispatchResult {
     let acc_id = ensure_signed(origin)?;
-    crate::WeightControlDelegation::<T>::remove(acc_id);
-    Ok(())
+
+    crate::WeightControlDelegation::<T>::mutate(acc_id, |val| match val.take() {
+        Some(_) => Ok(()),
+        None => Err(crate::Error::<T>::AgentIsNotDelegating.into()),
+    })
 }

--- a/pallets/emission0/tests/weights.rs
+++ b/pallets/emission0/tests/weights.rs
@@ -1,0 +1,103 @@
+use pallet_emission0::{
+    weights::{delegate_weight_control, regain_weight_control, set_weights},
+    ConsensusMembers, Error, MaxAllowedWeights, MinStakePerWeight, WeightControlDelegation,
+    Weights,
+};
+use test_utils::{add_stake, get_origin, register_empty_agent, Test};
+
+#[test]
+fn delegates_and_regains_weight_control() {
+    test_utils::new_test_ext().execute_with(|| {
+        let delegator = 0;
+        let delegated = 1;
+
+        assert_eq!(
+            delegate_weight_control::<Test>(get_origin(delegator), delegator),
+            Err(Error::<Test>::CannotDelegateWeightControlToSelf.into())
+        );
+
+        assert_eq!(
+            delegate_weight_control::<Test>(get_origin(delegator), delegated),
+            Err(Error::<Test>::AgentIsNotRegistered.into())
+        );
+
+        assert_eq!(
+            regain_weight_control::<Test>(get_origin(delegator)),
+            Err(Error::<Test>::AgentIsNotDelegating.into())
+        );
+
+        register_empty_agent(delegator);
+
+        assert_eq!(
+            delegate_weight_control::<Test>(get_origin(delegator), delegated),
+            Err(Error::<Test>::AgentIsNotRegistered.into())
+        );
+
+        register_empty_agent(delegated);
+
+        assert_eq!(
+            delegate_weight_control::<Test>(get_origin(delegator), delegated),
+            Ok(())
+        );
+
+        assert!(WeightControlDelegation::<Test>::contains_key(delegator));
+
+        assert_eq!(regain_weight_control::<Test>(get_origin(delegator)), Ok(()));
+
+        assert!(!WeightControlDelegation::<Test>::contains_key(delegator));
+    });
+}
+
+#[test]
+fn sets_weights_correctly() {
+    test_utils::new_test_ext().execute_with(|| {
+        MaxAllowedWeights::<Test>::set(5);
+        MinStakePerWeight::<Test>::set(1);
+
+        let validator = 0;
+
+        assert_eq!(
+            set_weights::<Test>(get_origin(validator), vec![(0, 0); 6]),
+            Err(Error::<Test>::WeightSetTooLarge.into()),
+        );
+
+        assert_eq!(
+            set_weights::<Test>(get_origin(validator), vec![(0, 0); 5]),
+            Err(Error::<Test>::AgentIsNotRegistered.into()),
+        );
+
+        register_empty_agent(validator);
+
+        assert_eq!(
+            set_weights::<Test>(get_origin(validator), vec![(0, 0); 5]),
+            Err(Error::<Test>::NotEnoughStakeToSetWeights.into()),
+        );
+
+        add_stake(validator, validator, 3);
+
+        assert_eq!(
+            set_weights::<Test>(get_origin(validator), vec![(0, 0); 5]),
+            Err(Error::<Test>::CannotSetWeightsForSelf.into()),
+        );
+
+        assert_eq!(
+            set_weights::<Test>(get_origin(validator), vec![(1, 0); 5]),
+            Err(Error::<Test>::AgentIsNotRegistered.into()),
+        );
+
+        register_empty_agent(1);
+        register_empty_agent(2);
+
+        assert_eq!(
+            set_weights::<Test>(get_origin(validator), vec![(1, 0), (1, 0), (2, 0)]),
+            Ok(()),
+        );
+
+        assert_eq!(
+            ConsensusMembers::<Test>::get(validator)
+                .expect("weights were not set")
+                .weights,
+            Weights::<Test>::truncate_from(vec![(1, 0), (2, 0)])
+        );
+    });
+}

--- a/pallets/governance/src/proposal.rs
+++ b/pallets/governance/src/proposal.rs
@@ -87,7 +87,7 @@ impl<T: crate::Config> Proposal<T> {
                 pallet_torus0::MaxNameLength::<T>::set(max_name_length);
                 pallet_torus0::MaxAllowedAgents::<T>::set(max_allowed_agents);
                 pallet_emission0::MaxAllowedWeights::<T>::set(max_allowed_weights);
-                pallet_torus0::MinWeightStake::<T>::set(min_weight_stake);
+                pallet_emission0::MinStakePerWeight::<T>::set(min_weight_stake);
                 pallet_torus0::FeeConstraints::<T>::mutate(|constraints| {
                     constraints.min_weight_control_fee =
                         Percent::from_percent(min_weight_control_fee);

--- a/pallets/torus0/src/lib.rs
+++ b/pallets/torus0/src/lib.rs
@@ -4,7 +4,7 @@ pub mod agent;
 mod balance;
 mod burn;
 mod ext;
-mod fee;
+pub mod fee;
 pub mod stake;
 
 use crate::agent::Agent;
@@ -41,12 +41,6 @@ pub mod pallet {
     pub type Burn<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 
     #[pallet::storage]
-    pub type MaximumSetWeightCallsPerEpoch<T: Config> = StorageValue<_, u16>;
-
-    #[pallet::storage]
-    pub type SetWeightCallsPerEpoch<T: Config> = StorageMap<_, Identity, T::AccountId, u16>;
-
-    #[pallet::storage]
     pub type IncentiveRatio<T: Config> = StorageValue<_, u16, ValueQuery>;
 
     #[pallet::storage]
@@ -80,9 +74,6 @@ pub mod pallet {
         StorageValue<_, u16, ValueQuery, T::DefaultMaxAllowedAgents>;
 
     #[pallet::storage]
-    pub type MinWeightStake<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
-
-    #[pallet::storage]
     pub type RegistrationsThisBlock<T> = StorageValue<_, u16, ValueQuery>;
 
     #[pallet::storage]
@@ -101,7 +92,7 @@ pub mod pallet {
     pub type TotalStake<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 
     #[pallet::storage]
-    pub type MinimumAllowedStake<T: Config> =
+    pub type MinAllowedStake<T: Config> =
         StorageValue<_, BalanceOf<T>, ValueQuery, T::DefaultMinimumAllowedStake>;
 
     #[pallet::storage]
@@ -416,7 +407,7 @@ impl<T: Config>
     }
 
     fn min_allowed_stake() -> u128 {
-        MinimumAllowedStake::<T>::get()
+        MinAllowedStake::<T>::get()
     }
 
     fn max_validators() -> u16 {

--- a/pallets/torus0/src/stake.rs
+++ b/pallets/torus0/src/stake.rs
@@ -12,7 +12,7 @@ pub fn add_stake<T: crate::Config>(
     amount: BalanceOf<T>,
 ) -> DispatchResult {
     ensure!(
-        amount >= crate::MinimumAllowedStake::<T>::get(),
+        amount >= crate::MinAllowedStake::<T>::get(),
         crate::Error::<T>::StakeTooSmall
     );
 
@@ -50,7 +50,7 @@ pub fn remove_stake<T: crate::Config>(
     amount: BalanceOf<T>,
 ) -> DispatchResult {
     ensure!(
-        amount >= crate::MinimumAllowedStake::<T>::get(),
+        amount >= crate::MinAllowedStake::<T>::get(),
         crate::Error::<T>::StakeTooSmall
     );
 

--- a/runtime/src/configs.rs
+++ b/runtime/src/configs.rs
@@ -363,6 +363,8 @@ parameter_types! {
 }
 
 impl pallet_emission0::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+
     type HalvingInterval = HalvingInterval;
 
     type MaxSupply = MaxSupply;


### PR DESCRIPTION
This is one of the last batches of tests for the emission0 pallet.

One change that the tests promoted was moving some of the types from fixed precision (`I96F32`) to substrate's `Perquintill` when calculating normalized values. The latter has much more precision than the former.

Closes CHAIN-33.