### PR TITLE
fix: hardcoded constants with wrong number of decimals

### DIFF
--- a/pallets/governance/src/config.rs
+++ b/pallets/governance/src/config.rs
@@ -19,12 +19,12 @@ pub struct GovernanceConfiguration<T: crate::Config> {
 impl<T: crate::Config> Default for GovernanceConfiguration<T> {
     fn default() -> Self {
         Self {
-            proposal_cost: 10_000_000_000_000,
+            proposal_cost: 10_000_000_000_000, // FIXME: decimals
             proposal_expiration: 130_000,
-            agent_application_cost: 1_000_000_000_000,
+            agent_application_cost: 1_000_000_000_000, // FIXME: decimals
             agent_application_expiration: 2_000,
             proposal_reward_treasury_allocation: Percent::from_percent(2),
-            max_proposal_reward_treasury_allocation: 10_000_000_000_000,
+            max_proposal_reward_treasury_allocation: 10_000_000_000_000, // FIXME: decimals
             proposal_reward_interval: 75_600,
         }
     }

--- a/runtime/src/configs.rs
+++ b/runtime/src/configs.rs
@@ -289,7 +289,7 @@ impl pallet_grandpa::Config for Runtime {
 // --- Torus ---
 
 impl pallet_torus0::Config for Runtime {
-    type DefaultMinValidatorStake = ConstU128<50_000_000_000_000>;
+    type DefaultMinValidatorStake = ConstU128<50_000_000_000_000>; // FIXME: decimals
 
     type DefaultImmunityPeriod = ConstU16<0>;
 
@@ -305,15 +305,15 @@ impl pallet_torus0::Config for Runtime {
 
     type DefaultMaxRegistrationsPerBlock = ConstU16<10>;
 
-    type DefaultMinimumAllowedStake = ConstU128<500000000>;
+    type DefaultMinimumAllowedStake = ConstU128<500_000_000>; // FIXME: decimals
 
     type DefaultMinStakingFee = ConstU8<5>;
 
     type DefaultMinWeightControlFee = ConstU8<4>;
 
-    type DefaultMinBurn = ConstU128<10_000_000_000>;
+    type DefaultMinBurn = ConstU128<10_000_000_000>; // FIXME: decimals
 
-    type DefaultMaxBurn = ConstU128<150_000_000_000>;
+    type DefaultMaxBurn = ConstU128<150_000_000_000>; // FIXME: decimals
 
     type DefaultAdjustmentAlpha = ConstU64<{ u64::MAX / 2 }>;
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -71,7 +71,7 @@ parameter_types! {
 }
 
 impl pallet_torus0::Config for Test {
-    type DefaultMinValidatorStake = ConstU128<50_000_000_000_000>;
+    type DefaultMinValidatorStake = ConstU128<50_000_000_000_000>; // FIXME: decimals
 
     type DefaultImmunityPeriod = ConstU16<0>;
 
@@ -93,9 +93,9 @@ impl pallet_torus0::Config for Test {
 
     type DefaultMinWeightControlFee = ConstU8<4>;
 
-    type DefaultMinBurn = ConstU128<10_000_000_000>;
+    type DefaultMinBurn = ConstU128<10_000_000_000>; // FIXME: decimals
 
-    type DefaultMaxBurn = ConstU128<150_000_000_000>;
+    type DefaultMaxBurn = ConstU128<150_000_000_000>; // FIXME: decimals
 
     type DefaultAdjustmentAlpha = ConstU64<{ u64::MAX / 2 }>;
 


### PR DESCRIPTION
There are hardcoded (currency) values with the wrong number of zeroes (decimals).

These should be ideally computed by multiplying the number of tokens with a const for the
token decimals coming from a shared config file (I'm not sure the best way to do this).

I have added `FIXME` tags on this PR to the hardcoded values with this problem that I found.

# Pull Request Checklist

Before submitting this PR, please make sure:

- [ ] You have run `cargo clippy` and addressed any warnings
- [ ] You have added appropriate tests (if applicable)
- [ ] You have updated the documentation (if applicable)
- [ ] You have reviewed your own code
- [ ] You have updated changelog (if applicable)

## Description

Please provide a brief description of the changes in this PR.

## Related Issues

Please link any related issues here
