### PR TITLE
fix: persist Applications instead of deleting and Remove applications

### DIFF
--- a/pallets/governance/src/lib.rs
+++ b/pallets/governance/src/lib.rs
@@ -69,9 +69,6 @@ pub mod pallet {
     pub type AgentApplications<T: Config> = StorageMap<_, Identity, u32, AgentApplication<T>>;
 
     #[pallet::storage]
-    pub type AgentApplicationId<T: Config> = StorageValue<_, u32, ValueQuery>;
-
-    #[pallet::storage]
     pub type Whitelist<T: Config> = StorageMap<_, Identity, AccountIdOf<T>, ()>;
 
     #[pallet::storage]

--- a/pallets/governance/src/whitelist.rs
+++ b/pallets/governance/src/whitelist.rs
@@ -1,10 +1,14 @@
 use polkadot_sdk::frame_support::dispatch::DispatchResult;
 
-use crate::AccountIdOf;
+use crate::{application, AccountIdOf};
 
 pub fn add_to_whitelist<T: crate::Config>(key: AccountIdOf<T>) -> DispatchResult {
     if is_whitelisted::<T>(&key) {
         return Err(crate::Error::<T>::AlreadyWhitelisted.into());
+    }
+
+    if application::exists_for_agent_key::<T>(&key, &application::ApplicationAction::Add) {
+        return Err(crate::Error::<T>::ApplicationKeyAlreadyUsed.into());
     }
 
     crate::Whitelist::<T>::insert(key.clone(), ());
@@ -15,6 +19,10 @@ pub fn add_to_whitelist<T: crate::Config>(key: AccountIdOf<T>) -> DispatchResult
 pub fn remove_from_whitelist<T: crate::Config>(key: AccountIdOf<T>) -> DispatchResult {
     if !is_whitelisted::<T>(&key) {
         return Err(crate::Error::<T>::NotWhitelisted.into());
+    }
+
+    if application::exists_for_agent_key::<T>(&key, &application::ApplicationAction::Remove) {
+        return Err(crate::Error::<T>::ApplicationKeyAlreadyUsed.into());
     }
 
     crate::Whitelist::<T>::remove(&key);

--- a/pallets/governance/tests/application.rs
+++ b/pallets/governance/tests/application.rs
@@ -1,9 +1,64 @@
+use pallet_governance::application::ApplicationStatus;
 use pallet_governance::AgentApplications;
 use pallet_governance::GlobalGovernanceConfig;
+use polkadot_sdk::frame_support::assert_err;
 use test_utils::*;
 
 #[test]
-fn whitelist_executes_application_correctly() {
+fn error_is_thrown_on_applying_add_already_whitelisted() {
+    new_test_ext().execute_with(|| {
+        zero_min_burn();
+
+        let key = 0;
+        let adding_key = 1;
+        pallet_governance::Curators::<Test>::insert(key, ());
+        pallet_governance::Whitelist::<Test>::insert(adding_key, ());
+
+        let proposal_cost = GlobalGovernanceConfig::<Test>::get().agent_application_cost;
+        let data = "test".as_bytes().to_vec();
+
+        add_balance(key, proposal_cost + 1);
+
+        assert_err!(
+            pallet_governance::Pallet::<Test>::submit_application(
+                get_origin(key),
+                adding_key,
+                data.clone(),
+                false
+            ),
+            pallet_governance::Error::<Test>::AlreadyWhitelisted
+        );
+    });
+}
+
+#[test]
+fn error_is_thrown_on_applying_remove_not_whitelisted() {
+    new_test_ext().execute_with(|| {
+        zero_min_burn();
+
+        let key = 0;
+        let adding_key = 1;
+        pallet_governance::Curators::<Test>::insert(key, ());
+
+        let proposal_cost = GlobalGovernanceConfig::<Test>::get().agent_application_cost;
+        let data = "test".as_bytes().to_vec();
+
+        add_balance(key, proposal_cost + 1);
+
+        assert_err!(
+            pallet_governance::Pallet::<Test>::submit_application(
+                get_origin(key),
+                adding_key,
+                data.clone(),
+                true
+            ),
+            pallet_governance::Error::<Test>::NotWhitelisted
+        );
+    });
+}
+
+#[test]
+fn whitelist_executes_application_correctly_add() {
     new_test_ext().execute_with(|| {
         zero_min_burn();
 
@@ -47,6 +102,101 @@ fn whitelist_executes_application_correctly() {
         assert!(pallet_governance::whitelist::is_whitelisted::<Test>(
             &adding_key
         ));
+
+        let application =
+            pallet_governance::AgentApplications::<Test>::get(application_id).unwrap();
+        assert_eq!(
+            application.status,
+            ApplicationStatus::Resolved { accepted: true }
+        );
+    });
+}
+
+#[test]
+fn whitelist_executes_application_correctly_remove() {
+    new_test_ext().execute_with(|| {
+        zero_min_burn();
+
+        let key = 0;
+        let adding_key = 1;
+        pallet_governance::Curators::<Test>::insert(key, ());
+
+        let proposal_cost = GlobalGovernanceConfig::<Test>::get().agent_application_cost;
+        let data = "test".as_bytes().to_vec();
+
+        add_balance(key, proposal_cost + 1);
+        // first submit an application
+        let balance_before = get_balance(key);
+
+        assert_ok!(pallet_governance::Pallet::<Test>::submit_application(
+            get_origin(key),
+            adding_key,
+            data.clone(),
+            false
+        ));
+
+        let balance_after = get_balance(key);
+        assert_eq!(balance_after, balance_before - proposal_cost);
+
+        let mut application_id: u32 = u32::MAX;
+        for (_, value) in AgentApplications::<Test>::iter() {
+            assert_eq!(value.agent_key, adding_key);
+            assert_eq!(value.data, data);
+            application_id = value.id;
+        }
+
+        assert_ok!(pallet_governance::Pallet::<Test>::accept_application(
+            get_origin(key),
+            application_id
+        ));
+
+        let balance_after_accept = get_balance(key);
+
+        assert_eq!(balance_after_accept, balance_before);
+
+        assert!(pallet_governance::whitelist::is_whitelisted::<Test>(
+            &adding_key
+        ));
+
+        let application =
+            pallet_governance::AgentApplications::<Test>::get(application_id).unwrap();
+        assert_eq!(
+            application.status,
+            ApplicationStatus::Resolved { accepted: true }
+        );
+    });
+}
+
+#[test]
+fn error_is_thrown_on_multiple_applications_same_key() {
+    new_test_ext().execute_with(|| {
+        zero_min_burn();
+
+        let key = 0;
+        let adding_key = 1;
+        pallet_governance::Curators::<Test>::insert(key, ());
+
+        let proposal_cost = GlobalGovernanceConfig::<Test>::get().agent_application_cost;
+        let data = "test".as_bytes().to_vec();
+
+        add_balance(key, (proposal_cost * 2) + 1);
+
+        assert_ok!(pallet_governance::Pallet::<Test>::submit_application(
+            get_origin(key),
+            adding_key,
+            data.clone(),
+            false
+        ));
+
+        assert_err!(
+            pallet_governance::Pallet::<Test>::submit_application(
+                get_origin(key),
+                adding_key,
+                data.clone(),
+                false
+            ),
+            pallet_governance::Error::<Test>::ApplicationKeyAlreadyUsed
+        );
     });
 }
 
@@ -92,5 +242,48 @@ fn application_denied_doesnt_add_to_whitelist() {
         assert!(!pallet_governance::whitelist::is_whitelisted::<Test>(
             &adding_key
         ));
+
+        let application =
+            pallet_governance::AgentApplications::<Test>::get(application_id).unwrap();
+        assert_eq!(
+            application.status,
+            ApplicationStatus::Resolved { accepted: false }
+        );
+    });
+}
+
+#[test]
+fn application_expires() {
+    new_test_ext().execute_with(|| {
+        let key = 0;
+        let adding_key = 1;
+        pallet_governance::Curators::<Test>::insert(key, ());
+
+        let proposal_cost = GlobalGovernanceConfig::<Test>::get().agent_application_cost;
+        let data = "test".as_bytes().to_vec();
+
+        add_balance(key, proposal_cost + 1);
+
+        assert_ok!(pallet_governance::Pallet::<Test>::submit_application(
+            get_origin(key),
+            adding_key,
+            data.clone(),
+            false
+        ));
+
+        let mut application_id: u32 = u32::MAX;
+        for (_, value) in AgentApplications::<Test>::iter() {
+            assert_eq!(value.agent_key, adding_key);
+            assert_eq!(value.data, data);
+            application_id = value.id;
+        }
+
+        step_block(
+            pallet_governance::GlobalGovernanceConfig::<Test>::get().agent_application_expiration,
+        );
+
+        let application =
+            pallet_governance::AgentApplications::<Test>::get(application_id).unwrap();
+        assert_eq!(application.status, ApplicationStatus::Expired);
     });
 }


### PR DESCRIPTION
Applications that are resolved (accepted/rejected) or expired will be
persisted in the chain state instead of being deleted to persist the changes
on the ledger and improve the consumption workflow of this data.

Also, now proposals can be used to _remove_ a key from the whitelist.

# Pull Request Checklist

Before submitting this PR, please make sure:

- [x] You have run `cargo clippy` and addressed any warnings
- [ ] You have added appropriate tests (if applicable)
- [ ] You have updated the documentation (if applicable)
- [x] You have reviewed your own code
- [ ] You have updated changelog (if applicable)

## Related Issues

#34
