### PR TITLE
chore: remove old commune stuff

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @supremesource @saiintbrisson @steinerkelvin @devwckd
+* @functor-flow @saiintbrisson @steinerkelvin @devwckd
 
 /.github/workflows/* @steinerkelvin @daviptrs @saiintbrisson
 /docker/**/*         @steinerkelvin @daviptrs @saiintbrisson

--- a/pallets/emission0/src/lib.rs
+++ b/pallets/emission0/src/lib.rs
@@ -51,21 +51,6 @@ pub mod pallet {
     pub type WeightControlDelegation<T: Config> =
         StorageMap<_, Identity, T::AccountId, T::AccountId>;
 
-    // TODO: remove
-    #[pallet::storage]
-    pub type MinAllowedWeights<T: Config> =
-        StorageValue<_, u16, ValueQuery, T::DefaultMinAllowedWeights>;
-
-    /// Maximum number of weights a validator can set.
-    #[pallet::storage]
-    pub type MaxAllowedWeights<T: Config> =
-        StorageValue<_, u16, ValueQuery, T::DefaultMaxAllowedWeights>;
-
-    // TODO: cap weights on distribution.
-    /// Minimum stake a validator needs for each weight it sets.
-    #[pallet::storage]
-    pub type MinStakePerWeight<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
-
     /// Percentage of issued tokens to be burned every epoch.
     #[pallet::storage]
     pub type EmissionRecyclingPercentage<T: Config> =

--- a/pallets/emission0/tests/distribution.rs
+++ b/pallets/emission0/tests/distribution.rs
@@ -13,7 +13,7 @@ use polkadot_sdk::{
 use substrate_fixed::{traits::ToFixed, types::I96F32};
 use test_utils::{
     add_balance, add_stake, get_origin,
-    pallet_governance::TreasuryEmissionFee,
+    pallet_governance::{Allocators, TreasuryEmissionFee},
     pallet_torus0::{
         stake::sum_staked_by, Agents, FeeConstraints, MaxAllowedValidators, MinAllowedStake,
         MinValidatorStake, StakedBy,
@@ -488,6 +488,8 @@ fn pays_weight_control_fee_and_dividends_to_stakers() {
         for id in [val_1, val_2, miner] {
             register_empty_agent(id);
         }
+
+        Allocators::<Test>::set(val_1, Some(()));
 
         pallet_emission0::weight_control::delegate_weight_control::<Test>(get_origin(val_2), val_1)
             .expect("failed to delegate weight control");

--- a/pallets/emission0/tests/weights.rs
+++ b/pallets/emission0/tests/weights.rs
@@ -1,10 +1,10 @@
 use pallet_emission0::{
     weight_control::{delegate_weight_control, regain_weight_control, set_weights},
-    ConsensusMembers, Error, MaxAllowedWeights, MinStakePerWeight, WeightControlDelegation,
-    Weights,
+    ConsensusMembers, Error, WeightControlDelegation, Weights,
 };
 use test_utils::{
-    add_stake, get_origin, pallet_governance::Allocators, register_empty_agent, Test,
+    add_stake, get_origin, pallet_governance::Allocators, pallet_torus0::MinValidatorStake,
+    register_empty_agent, Test,
 };
 
 #[test]
@@ -37,6 +37,11 @@ fn delegates_and_regains_weight_control() {
 
         register_empty_agent(delegated);
 
+        delegate_weight_control::<Test>(get_origin(delegator), delegated)
+            .expect_err("cannot delegate to not-allocator");
+
+        Allocators::<Test>::set(delegated, Some(()));
+
         assert_eq!(
             delegate_weight_control::<Test>(get_origin(delegator), delegated),
             Ok(())
@@ -52,9 +57,6 @@ fn delegates_and_regains_weight_control() {
 #[test]
 fn sets_weights_correctly() {
     test_utils::new_test_ext().execute_with(|| {
-        MaxAllowedWeights::<Test>::set(5);
-        MinStakePerWeight::<Test>::set(1);
-
         let validator = 0;
 
         assert_eq!(
@@ -72,16 +74,11 @@ fn sets_weights_correctly() {
         register_empty_agent(validator);
 
         assert_eq!(
-            set_weights::<Test>(get_origin(validator), vec![(0, 0); 6]),
-            Err(Error::<Test>::WeightSetTooLarge.into()),
-        );
-
-        assert_eq!(
             set_weights::<Test>(get_origin(validator), vec![(0, 0); 5]),
             Err(Error::<Test>::NotEnoughStakeToSetWeights.into()),
         );
 
-        add_stake(validator, validator, 3);
+        add_stake(validator, validator, MinValidatorStake::<Test>::get());
 
         assert_eq!(
             set_weights::<Test>(get_origin(validator), vec![(0, 0); 5]),
@@ -95,6 +92,8 @@ fn sets_weights_correctly() {
 
         register_empty_agent(1);
         register_empty_agent(2);
+
+        Allocators::<Test>::set(1, Some(()));
 
         delegate_weight_control::<Test>(get_origin(validator), 1)
             .expect("failed to delegate weight control");

--- a/pallets/governance/src/benchmarks.rs
+++ b/pallets/governance/src/benchmarks.rs
@@ -10,7 +10,7 @@ use crate::*;
 fn create_application<T: Config>(module_key: &T::AccountId) {
     let config = crate::GlobalGovernanceConfig::<T>::get();
     let cost = config.agent_application_cost;
-    let _ = <T as crate::Config>::Currency::deposit_creating(&module_key, cost);
+    let _ = <T as crate::Config>::Currency::deposit_creating(module_key, cost);
 
     let min_data_len = T::MinApplicationDataLength::get();
     let data = vec![0; min_data_len as usize];
@@ -112,8 +112,6 @@ benchmarks! {
             min_name_length: 2,
             max_name_length: T::MaxAgentNameLengthConstraint::get() as u16 - 1,
             max_allowed_agents: 1,
-            max_allowed_weights: 1,
-            min_stake_per_weight: 0,
             min_weight_control_fee: 1,
             min_staking_fee: 1,
             dividends_participation_weight: Percent::zero(),

--- a/pallets/governance/src/config.rs
+++ b/pallets/governance/src/config.rs
@@ -1,21 +1,22 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use polkadot_sdk::{
-    frame_election_provider_support::Get, frame_support::DebugNoBound, sp_runtime::Percent,
+    frame_election_provider_support::Get, frame_support::DebugNoBound,
+    polkadot_sdk_frame::prelude::BlockNumberFor, sp_runtime::Percent,
 };
 use scale_info::TypeInfo;
 
-use crate::{BalanceOf, BlockAmount};
+use crate::BalanceOf;
 
 #[derive(Clone, TypeInfo, Decode, Encode, PartialEq, Eq, DebugNoBound, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
 pub struct GovernanceConfiguration<T: crate::Config> {
     pub proposal_cost: BalanceOf<T>,
-    pub proposal_expiration: BlockAmount,
+    pub proposal_expiration: BlockNumberFor<T>,
     pub agent_application_cost: BalanceOf<T>,
-    pub agent_application_expiration: BlockAmount,
+    pub agent_application_expiration: BlockNumberFor<T>,
     pub proposal_reward_treasury_allocation: Percent,
     pub max_proposal_reward_treasury_allocation: BalanceOf<T>,
-    pub proposal_reward_interval: BlockAmount,
+    pub proposal_reward_interval: BlockNumberFor<T>,
 }
 
 impl<T: crate::Config> Default for GovernanceConfiguration<T> {

--- a/pallets/governance/src/ext.rs
+++ b/pallets/governance/src/ext.rs
@@ -5,7 +5,3 @@ pub(super) type BalanceOf<T> = <<T as crate::Config>::Currency as Currency<
 >>::Balance;
 
 pub(super) type AccountIdOf<T> = <T as polkadot_sdk::frame_system::Config>::AccountId;
-
-pub(super) type Block = u64;
-
-pub(super) type BlockAmount = u64;

--- a/pallets/governance/src/lib.rs
+++ b/pallets/governance/src/lib.rs
@@ -119,7 +119,8 @@ pub mod pallet {
         type MaxApplicationDataLength: Get<u32>;
 
         #[pallet::constant]
-        type ApplicationExpiration: Get<BlockAmount>;
+        #[pallet::no_default_bounds]
+        type ApplicationExpiration: Get<BlockNumberFor<Self>>;
 
         #[pallet::constant]
         type MaxPenaltyPercentage: Get<Percent>;
@@ -132,14 +133,16 @@ pub mod pallet {
         type DefaultProposalCost: Get<BalanceOf<Self>>;
 
         #[pallet::constant]
-        type DefaultProposalExpiration: Get<BlockAmount>;
+        #[pallet::no_default_bounds]
+        type DefaultProposalExpiration: Get<BlockNumberFor<Self>>;
 
         #[pallet::constant]
         #[pallet::no_default_bounds]
         type DefaultAgentApplicationCost: Get<BalanceOf<Self>>;
 
         #[pallet::constant]
-        type DefaultAgentApplicationExpiration: Get<BlockAmount>;
+        #[pallet::no_default_bounds]
+        type DefaultAgentApplicationExpiration: Get<BlockNumberFor<Self>>;
 
         #[pallet::constant]
         type DefaultProposalRewardTreasuryAllocation: Get<Percent>;
@@ -149,7 +152,8 @@ pub mod pallet {
         type DefaultMaxProposalRewardTreasuryAllocation: Get<BalanceOf<Self>>;
 
         #[pallet::constant]
-        type DefaultProposalRewardInterval: Get<BlockAmount>;
+        #[pallet::no_default_bounds]
+        type DefaultProposalRewardInterval: Get<BlockNumberFor<Self>>;
 
         #[pallet::no_default_bounds]
         type RuntimeEvent: From<Event<Self>>
@@ -167,14 +171,10 @@ pub mod pallet {
     #[pallet::hooks]
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
         fn on_initialize(block_number: BlockNumberFor<T>) -> Weight {
-            let current_block: u64 = block_number
-                .try_into()
-                .ok()
-                .expect("blockchain won't pass 2 ^ 64 blocks");
+            application::resolve_expired_applications::<T>(block_number);
 
-            application::resolve_expired_applications::<T>(current_block);
-            proposal::tick_proposals::<T>(current_block);
-            proposal::tick_proposal_rewards::<T>(current_block);
+            proposal::tick_proposals::<T>(block_number);
+            proposal::tick_proposal_rewards::<T>(block_number);
 
             Weight::zero()
         }

--- a/pallets/governance/tests/voting.rs
+++ b/pallets/governance/tests/voting.rs
@@ -111,15 +111,6 @@ fn global_governance_config_validates_parameters_correctly() {
 
         assert_err!(
             GlobalParamsData::<Test> {
-                max_allowed_weights: 2001,
-                ..GlobalParamsData::default()
-            }
-            .validate(),
-            Error::<Test>::InvalidMaxAllowedWeights
-        );
-
-        assert_err!(
-            GlobalParamsData::<Test> {
                 min_weight_control_fee: 101,
                 ..GlobalParamsData::default()
             }

--- a/pallets/torus0/src/lib.rs
+++ b/pallets/torus0/src/lib.rs
@@ -68,11 +68,6 @@ pub mod pallet {
     #[pallet::storage]
     pub type Agents<T: Config> = StorageMap<_, Identity, AccountIdOf<T>, Agent<T>>;
 
-    // TODO: remove
-    #[pallet::storage]
-    pub type RegistrationBlock<T: Config> =
-        StorageMap<_, Identity, AccountIdOf<T>, BlockNumberFor<T>>;
-
     /// Maximum number of characters allowed in an agent name.
     #[pallet::storage]
     pub type MaxNameLength<T: Config> = StorageValue<_, u16, ValueQuery, T::DefaultMaxNameLength>;

--- a/pallets/torus0/src/stake.rs
+++ b/pallets/torus0/src/stake.rs
@@ -78,7 +78,7 @@ pub fn remove_stake<T: crate::Config>(
 
     let _ = <T as crate::Config>::Currency::deposit_creating(&staker, amount);
 
-    crate::Pallet::<T>::deposit_event(crate::Event::<T>::StakeRemoved(key, agent_key, amount));
+    crate::Pallet::<T>::deposit_event(crate::Event::<T>::StakeRemoved(staker, staked, amount));
 
     Ok(())
 }

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -19,7 +19,7 @@ fn main() {
     #[cfg(feature = "std")]
     {
         substrate_wasm_builder::WasmBuilder::init_with_defaults()
-            .enable_metadata_hash("TORUS", 18) // TODO: disable on dev/local? this increases build times 100%+
+            .enable_metadata_hash("TORUS", 18)
             .build();
     }
 }


### PR DESCRIPTION
Removes unused storage values from Commune times.

Storage values removed:
* `MinAllowedWeights`,
* `MaxAllowedWeights`,
* `MinStakePerWeight`,
* `RegistrationBlock` (in favor of `registration_block` within the Agent value).
 
Fields removed from `GlobalParamsData`:
* `max_allowed_weights`,
* `min_stake_per_weight`.