### PR TITLE
fix: automatically delegate weights to allocator

### DIFF
--- a/pallets/emission0/api/src/lib.rs
+++ b/pallets/emission0/api/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+use polkadot_sdk::frame_support::dispatch::DispatchResult;
+
 #[derive(Default)]
 pub struct ConsensusMemberStats {
     pub incentives: u16,
@@ -11,4 +13,6 @@ pub trait Emission0Api<AccountId> {
     /// Returns `None` if the agent has not taken part in the last consensus
     /// run.
     fn consensus_stats(member: &AccountId) -> Option<ConsensusMemberStats>;
+
+    fn delegate_weight_control(delegator: &AccountId, delegatee: &AccountId) -> DispatchResult;
 }

--- a/pallets/emission0/src/lib.rs
+++ b/pallets/emission0/src/lib.rs
@@ -25,11 +25,12 @@ pub mod weights;
 
 #[frame::pallet]
 pub mod pallet {
-    const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
     use core::num::NonZeroU128;
 
     use frame::prelude::BlockNumberFor;
+    use frame_system::ensure_signed;
     use pallet_governance_api::GovernanceApi;
     use pallet_torus0_api::Torus0Api;
     use polkadot_sdk::sp_std;
@@ -145,6 +146,9 @@ pub mod pallet {
 
         /// Agent does not have enough stake to set weights.
         NotEnoughStakeToSetWeights,
+
+        /// At the current state, agents cannot control their own weight.
+        WeightControlNotEnabled,
     }
 
     #[pallet::event]
@@ -173,6 +177,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             target: AccountIdOf<T>,
         ) -> DispatchResult {
+            let origin = ensure_signed(origin)?;
             weight_control::delegate_weight_control::<T>(origin, target)
         }
 
@@ -211,5 +216,12 @@ impl<T: Config> Emission0Api<T::AccountId> for Pallet<T> {
                 incentives: member.last_incentives,
             }
         })
+    }
+
+    fn delegate_weight_control(
+        delegator: &T::AccountId,
+        delegatee: &T::AccountId,
+    ) -> DispatchResult {
+        weight_control::delegate_weight_control::<T>(delegator.clone(), delegatee.clone())
     }
 }

--- a/pallets/emission0/src/migrations.rs
+++ b/pallets/emission0/src/migrations.rs
@@ -1,23 +1,43 @@
-use polkadot_sdk::{
-    frame_support::{
-        migrations::VersionedMigration, traits::UncheckedOnRuntimeUpgrade, weights::Weight,
-    },
-    sp_runtime::Percent,
+use polkadot_sdk::frame_support::{
+    migrations::VersionedMigration, traits::UncheckedOnRuntimeUpgrade, weights::Weight,
 };
 
 use crate::{Config, Pallet};
 
-pub mod v1 {
+pub mod v2 {
+    use polkadot_sdk::sp_std::collections::btree_set::BTreeSet;
+
+    use pallet_emission0_api::Emission0Api;
+    use pallet_governance_api::GovernanceApi;
+    use pallet_torus0_api::Torus0Api;
+
     use super::*;
-    use crate::{EmissionRecyclingPercentage, IncentivesRatio};
 
-    pub type Migration<T, W> = VersionedMigration<0, 1, MigrateToV1<T>, Pallet<T>, W>;
-    pub struct MigrateToV1<T>(core::marker::PhantomData<T>);
+    pub type Migration<T, W> = VersionedMigration<1, 2, MigrateToV2<T>, Pallet<T>, W>;
+    pub struct MigrateToV2<T>(core::marker::PhantomData<T>);
 
-    impl<T: Config> UncheckedOnRuntimeUpgrade for MigrateToV1<T> {
+    impl<T: Config> UncheckedOnRuntimeUpgrade for MigrateToV2<T> {
         fn on_runtime_upgrade() -> Weight {
-            EmissionRecyclingPercentage::<T>::set(Percent::from_percent(81));
-            IncentivesRatio::<T>::set(Percent::from_percent(30));
+            let allocators: BTreeSet<_> = <T::Governance>::get_allocators().collect();
+            if let Some(allocator) = allocators.first() {
+                for agent in <T::Torus>::agent_ids() {
+                    if allocators.contains(&agent) {
+                        continue;
+                    }
+
+                    if let Err(err) =
+                        <Pallet<T> as Emission0Api<T::AccountId>>::delegate_weight_control(
+                            &agent, allocator,
+                        )
+                    {
+                        polkadot_sdk::sp_tracing::error!(
+                            "failed to delegate weight control from {agent:?} to {allocator:?}: {err:?}"
+                        );
+                    }
+                }
+            } else {
+                polkadot_sdk::sp_tracing::error!("no allocators available");
+            }
 
             Weight::zero()
         }

--- a/pallets/emission0/tests/distribution.rs
+++ b/pallets/emission0/tests/distribution.rs
@@ -12,7 +12,7 @@ use polkadot_sdk::{
 };
 use substrate_fixed::{traits::ToFixed, types::I96F32};
 use test_utils::{
-    add_balance, add_stake, get_origin,
+    add_balance, add_stake,
     pallet_governance::{Allocators, TreasuryEmissionFee},
     pallet_torus0::{
         stake::sum_staked_by, Agents, FeeConstraints, MaxAllowedValidators, MinAllowedStake,
@@ -491,7 +491,7 @@ fn pays_weight_control_fee_and_dividends_to_stakers() {
 
         Allocators::<Test>::set(val_1, Some(()));
 
-        pallet_emission0::weight_control::delegate_weight_control::<Test>(get_origin(val_2), val_1)
+        pallet_emission0::weight_control::delegate_weight_control::<Test>(val_2, val_1)
             .expect("failed to delegate weight control");
 
         let val_1_staker = 3;

--- a/pallets/emission0/tests/weights.rs
+++ b/pallets/emission0/tests/weights.rs
@@ -14,47 +14,55 @@ fn delegates_and_regains_weight_control() {
         let delegated = 1;
 
         assert_eq!(
-            delegate_weight_control::<Test>(get_origin(delegator), delegator),
+            delegate_weight_control::<Test>(delegator, delegator),
             Err(Error::<Test>::CannotDelegateWeightControlToSelf.into())
         );
 
         assert_eq!(
-            delegate_weight_control::<Test>(get_origin(delegator), delegated),
+            delegate_weight_control::<Test>(delegator, delegated),
             Err(Error::<Test>::AgentIsNotRegistered.into())
         );
 
-        assert_eq!(
-            regain_weight_control::<Test>(get_origin(delegator)),
-            Err(Error::<Test>::AgentIsNotDelegating.into())
-        );
+        // TODO: reenable when weight control is enabled again
+        // assert_eq!(
+        //     regain_weight_control::<Test>(get_origin(delegator)),
+        //     Err(Error::<Test>::AgentIsNotDelegating.into())
+        // );
 
         register_empty_agent(delegator);
 
         assert_eq!(
-            delegate_weight_control::<Test>(get_origin(delegator), delegated),
+            delegate_weight_control::<Test>(delegator, delegated),
             Err(Error::<Test>::AgentIsNotRegistered.into())
         );
 
         register_empty_agent(delegated);
 
-        delegate_weight_control::<Test>(get_origin(delegator), delegated)
+        delegate_weight_control::<Test>(delegator, delegated)
             .expect_err("cannot delegate to not-allocator");
 
         Allocators::<Test>::set(delegated, Some(()));
 
         assert_eq!(
-            delegate_weight_control::<Test>(get_origin(delegator), delegated),
+            delegate_weight_control::<Test>(delegator, delegated),
             Ok(())
         );
 
         assert!(WeightControlDelegation::<Test>::contains_key(delegator));
 
-        assert_eq!(regain_weight_control::<Test>(get_origin(delegator)), Ok(()));
-        assert!(!WeightControlDelegation::<Test>::contains_key(delegator));
+        assert_eq!(
+            regain_weight_control::<Test>(get_origin(delegator)),
+            Err(Error::<Test>::WeightControlNotEnabled.into())
+        );
+
+        // TODO: reenable when weight control is enabled
+        // assert_eq!(regain_weight_control::<Test>(get_origin(delegator)), Ok(()));
+        // assert!(!WeightControlDelegation::<Test>::contains_key(delegator));
     });
 }
 
 #[test]
+#[allow(unreachable_code)]
 fn sets_weights_correctly() {
     test_utils::new_test_ext().execute_with(|| {
         let validator = 0;
@@ -95,8 +103,7 @@ fn sets_weights_correctly() {
 
         Allocators::<Test>::set(1, Some(()));
 
-        delegate_weight_control::<Test>(get_origin(validator), 1)
-            .expect("failed to delegate weight control");
+        delegate_weight_control::<Test>(validator, 1).expect("failed to delegate weight control");
 
         assert_eq!(
             set_weights::<Test>(get_origin(validator), vec![(1, 0); 5]),

--- a/pallets/governance/api/src/lib.rs
+++ b/pallets/governance/api/src/lib.rs
@@ -11,5 +11,7 @@ pub trait GovernanceApi<AccountId> {
 
     fn ensure_allocator(key: &AccountId) -> DispatchResult;
 
+    fn get_allocators() -> impl Iterator<Item = AccountId>;
+
     fn set_allocator(key: &AccountId);
 }

--- a/pallets/governance/src/lib.rs
+++ b/pallets/governance/src/lib.rs
@@ -42,7 +42,7 @@ use crate::{
 pub mod pallet {
     #![allow(clippy::too_many_arguments)]
 
-    const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
     use proposal::GlobalParamsData;
     use weights::WeightInfo;
@@ -531,6 +531,10 @@ impl<T: Config> pallet_governance_api::GovernanceApi<T::AccountId> for Pallet<T>
 
     fn ensure_allocator(key: &T::AccountId) -> DispatchResult {
         crate::roles::ensure_allocator::<T>(key)
+    }
+
+    fn get_allocators() -> impl Iterator<Item = T::AccountId> {
+        Allocators::<T>::iter_keys()
     }
 
     fn set_allocator(key: &T::AccountId) {

--- a/pallets/governance/src/migrations.rs
+++ b/pallets/governance/src/migrations.rs
@@ -1,41 +1,17 @@
-use polkadot_sdk::{
-    frame_support::{
-        migrations::VersionedMigration, traits::UncheckedOnRuntimeUpgrade, weights::Weight,
-    },
-    sp_runtime::Percent,
+use polkadot_sdk::frame_support::{
+    migrations::VersionedMigration, traits::UncheckedOnRuntimeUpgrade, weights::Weight,
 };
 
 use crate::{Config, Pallet};
 
-pub type Migrations<T, W> = (v1::Migration<T, W>, v2::Migration<T, W>);
-
-pub mod v2 {
+pub mod v3 {
     use super::*;
-    use crate::TreasuryEmissionFee;
 
-    pub type Migration<T, W> = VersionedMigration<1, 2, MigrateToV2<T>, Pallet<T>, W>;
-    pub struct MigrateToV2<T>(core::marker::PhantomData<T>);
+    pub type Migration<T, W> = VersionedMigration<2, 3, MigrateToV3<T>, Pallet<T>, W>;
+    pub struct MigrateToV3<T>(core::marker::PhantomData<T>);
 
-    impl<T: Config> UncheckedOnRuntimeUpgrade for MigrateToV2<T> {
+    impl<T: Config> UncheckedOnRuntimeUpgrade for MigrateToV3<T> {
         fn on_runtime_upgrade() -> Weight {
-            // Set Treasury emission fee to 5%
-            TreasuryEmissionFee::<T>::put(Percent::from_percent(5));
-
-            Weight::zero()
-        }
-    }
-}
-
-pub mod v1 {
-    use super::*;
-    use crate::GlobalGovernanceConfig;
-
-    pub type Migration<T, W> = VersionedMigration<0, 1, MigrateToV1<T>, Pallet<T>, W>;
-    pub struct MigrateToV1<T>(core::marker::PhantomData<T>);
-
-    impl<T: Config> UncheckedOnRuntimeUpgrade for MigrateToV1<T> {
-        fn on_runtime_upgrade() -> Weight {
-            GlobalGovernanceConfig::<T>::put(crate::config::GovernanceConfiguration::default());
             Weight::zero()
         }
     }

--- a/pallets/torus0/src/migrations.rs
+++ b/pallets/torus0/src/migrations.rs
@@ -1,29 +1,8 @@
-use polkadot_sdk::{
-    frame_support::{
-        migrations::VersionedMigration, traits::UncheckedOnRuntimeUpgrade, weights::Weight,
-    },
-    sp_runtime::Percent,
+use polkadot_sdk::frame_support::{
+    migrations::VersionedMigration, traits::UncheckedOnRuntimeUpgrade, weights::Weight,
 };
 
 use crate::{Config, Pallet};
-
-pub mod v1 {
-    use super::*;
-    use crate::{Agent, Agents};
-
-    pub type Migration<T, W> = VersionedMigration<0, 1, MigrateToV1<T>, Pallet<T>, W>;
-    pub struct MigrateToV1<T>(core::marker::PhantomData<T>);
-
-    impl<T: Config> UncheckedOnRuntimeUpgrade for MigrateToV1<T> {
-        fn on_runtime_upgrade() -> Weight {
-            Agents::<T>::translate(|_key, mut agent: Agent<T>| {
-                agent.weight_penalty_factor = Percent::from_percent(0);
-                Some(agent)
-            });
-            Weight::zero()
-        }
-    }
-}
 
 pub mod v2 {
     use super::*;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -85,10 +85,8 @@ pub type SignedPayload = sp_runtime::generic::SignedPayload<RuntimeCall, SignedE
 ///
 /// This can be a tuple of types, each implementing `OnRuntimeUpgrade`.
 type Migrations = (
-    pallet_governance::migrations::v1::Migration<Runtime, RocksDbWeight>,
-    pallet_governance::migrations::v2::Migration<Runtime, RocksDbWeight>,
-    pallet_emission0::migrations::v1::Migration<Runtime, RocksDbWeight>,
-    pallet_torus0::migrations::v1::Migration<Runtime, RocksDbWeight>,
+    pallet_governance::migrations::v3::Migration<Runtime, RocksDbWeight>,
+    pallet_emission0::migrations::v2::Migration<Runtime, RocksDbWeight>,
     pallet_torus0::migrations::v2::Migration<Runtime, RocksDbWeight>,
 );
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -8,9 +8,7 @@ pub use pallet_torus0;
 use pallet_torus0::MinAllowedStake;
 use polkadot_sdk::{
     frame_support::{
-        self,
-        pallet_prelude::DispatchResult,
-        parameter_types,
+        self, parameter_types,
         traits::{Currency, Everything, Hooks},
         PalletId,
     },
@@ -84,28 +82,6 @@ parameter_types! {
     pub const MaxLocks: u32 = 50;
     pub const MaxReserves: u32 = 50;
     pub const DefaultDividendsParticipationWeight: Percent = Percent::from_parts(40);
-}
-
-impl pallet_governance_api::GovernanceApi<AccountId> for Test {
-    fn dao_treasury_address() -> AccountId {
-        pallet_governance::DaoTreasuryAddress::<Test>::get()
-    }
-
-    fn treasury_emission_fee() -> Percent {
-        pallet_governance::TreasuryEmissionFee::<Test>::get()
-    }
-
-    fn is_whitelisted(key: &AccountId) -> bool {
-        pallet_governance::Whitelist::<Test>::contains_key(key)
-    }
-
-    fn ensure_allocator(key: &AccountId) -> DispatchResult {
-        pallet_governance::roles::ensure_allocator::<Test>(key)
-    }
-
-    fn set_allocator(key: &AccountId) {
-        pallet_governance::Allocators::<Test>::insert(key, ());
-    }
 }
 
 impl pallet_torus0::Config for Test {


### PR DESCRIPTION
Updates weight control code to better handle the current state. This means all agents will automatically delegate weights to the allocator. Closes CHAIN-69.