### PR TITLE
feat: build and push xtask cli tool to github packages

### DIFF
--- a/.github/workflows/build-docker-xtask.yml
+++ b/.github/workflows/build-docker-xtask.yml
@@ -1,0 +1,49 @@
+name: Docker build and push xtask cli tool
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+    paths:
+      - 'xtask/**'
+      - '.github/workflows/build-docker-xtask.yml'
+      - 'docker/xtask.dockerfile'
+    
+jobs:
+  docker:
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/torus-xtask
+          tags: |
+            type=sha,prefix=,enable=true
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: ./docker/xtask.dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/xtask.dockerfile
+++ b/docker/xtask.dockerfile
@@ -1,0 +1,35 @@
+FROM rust:1.76-slim-bullseye as builder
+
+WORKDIR /usr/src/app
+
+RUN apt-get update && apt install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    build-essential \
+    protobuf-compiler \
+    libclang-dev \
+    git \
+    pkg-config \
+    libssl-dev
+
+COPY . .
+
+RUN cargo build --release --bin xtask
+
+FROM debian:bullseye-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    build-essential \
+    protobuf-compiler \
+    libclang-dev \
+    git \
+    pkg-config \
+    libssl-dev
+
+COPY --from=builder /usr/src/app/target/release/xtask /usr/local/bin
+
+ENTRYPOINT ["xtask"]


### PR DESCRIPTION
This PR adds the `Docker build and push xtask cli tool` action.  
  
When code that changes anything related to the xtask is pushed to the branch `dev` or `main` this action builds a docker image and publishes it on github packages.  
  
The image tag is `ghcr.io/renlabs-dev/torus-xtask:{commit small sha}` with the addition of `ghcr.io/renlabs-dev/torus-xtask:latest` if it's pushed to `main`.

Closes CHAIN-71
