### PR TITLE
chore: publish autogenerated docs to github pages on push to the `main` branch

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - chore/docs
     
 jobs:
   publish:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,47 @@
+name: Build docs and publish to github pages
+
+on:
+  push:
+    branches:
+      - main
+      - chore/docs
+    
+jobs:
+  publish:
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+      
+      - name: Install Rust toolchain
+        run: |
+          rustup set profile minimal
+          rustup show
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: 3.20.1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docs
+        run: |
+          cargo doc --workspace --no-deps
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'target/doc/'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ We maintain several documentation files to help you understand and contribute to
 
 - [docs/xtask-manual.md](docs/xtask-manual.md): Comprehensive guide to the `xtask` command-line tool that simplifies local development, testing, and network simulation
 
-- [pallet_emission0 docs](https://renlabs-dev.github.io/torus-substrate/pallet_emission0): Generated docs for the create `pallet_emission0`  
+- [pallet_emission0 docs](https://renlabs-dev.github.io/torus-substrate/pallet_emission0): Generated docs for the crate `pallet_emission0`  
 
-- [pallet_governance docs](https://renlabs-dev.github.io/torus-substrate/pallet_governance): Generated docs for the create `pallet_governance`  
+- [pallet_governance docs](https://renlabs-dev.github.io/torus-substrate/pallet_governance): Generated docs for the crate `pallet_governance`  
 
-- [pallet_permission0 docs](https://renlabs-dev.github.io/torus-substrate/pallet_permission0): Generated docs for the create `pallet_permission0`  
+- [pallet_permission0 docs](https://renlabs-dev.github.io/torus-substrate/pallet_permission0): Generated docs for the crate `pallet_permission0`  
 
-- [pallet_torus0 docs](https://renlabs-dev.github.io/torus-substrate/pallet_torus0): Generated docs for the create `pallet_torus0`  
+- [pallet_torus0 docs](https://renlabs-dev.github.io/torus-substrate/pallet_torus0): Generated docs for the crate `pallet_torus0`  
 
 ## Terminology
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ We maintain several documentation files to help you understand and contribute to
 
 - [docs/xtask-manual.md](docs/xtask-manual.md): Comprehensive guide to the `xtask` command-line tool that simplifies local development, testing, and network simulation
 
+- [pallet_emission0 docs](https://renlabs-dev.github.io/torus-substrate/pallet_emission0): Generated docs for the create `pallet_emission0`  
+
+- [pallet_governance docs](https://renlabs-dev.github.io/torus-substrate/pallet_governance): Generated docs for the create `pallet_governance`  
+
+- [pallet_permission0 docs](https://renlabs-dev.github.io/torus-substrate/pallet_permission0): Generated docs for the create `pallet_permission0`  
+
+- [pallet_torus0 docs](https://renlabs-dev.github.io/torus-substrate/pallet_torus0): Generated docs for the create `pallet_torus0`  
+
 ## Terminology
 
 We have some specific terminology throughout the codebase, so here's a list of the most important ones:


### PR DESCRIPTION
Adds a CI task that generates the pallet docs and uploads them to [github pages](http://renlabs-dev.github.io/torus-substrate/pallet_torus0)
Closes CHAIN-75