### PR TITLE
refac(permission0): general pre-release tweaks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
   "rust-analyzer.check.extraEnv": {
     "SKIP_WASM_BUILD": "1"
   },
-  "rust-analyzer.cargo.features": ["runtime-benchmarks"],
+  "rust-analyzer.cargo.features": ["runtime-benchmarks", "testnet"],
   "coverage-gutters.coverageFileNames": ["target/cov.xml"],
   // Spell checker
   "cSpell.words": [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8471,6 +8471,7 @@ dependencies = [
  "pallet-torus0-api",
  "parity-scale-codec",
  "polkadot-sdk",
+ "rand 0.9.1",
  "scale-info",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ num-traits = { version = "0.2.19", default-features = false, features = [
     "libm",
 ] }
 bitflags = { version = "2.9.1", default-features = false }
+rand = { version = "0.9.1", default-features = false }
 
 # Frontier / EVM
 fc-api = { git = "https://github.com/paritytech/frontier.git", rev = "b9b1c620c8b418bdeeadc79725f9cfa4703c0333" }

--- a/pallets/faucet/Cargo.toml
+++ b/pallets/faucet/Cargo.toml
@@ -33,3 +33,4 @@ pallet-torus0.workspace = true
 pallet-emission0.workspace = true
 pallet-permission0.workspace = true
 pallet-governance-api.workspace = true
+rand = { workspace = true, features = ["thread_rng"] }

--- a/pallets/governance/src/benchmarking.rs
+++ b/pallets/governance/src/benchmarking.rs
@@ -140,7 +140,7 @@ mod benchmarks {
 
         let params = proposal::GlobalParamsData {
             min_name_length: 2,
-            max_name_length: T::MaxAgentNameLengthConstraint::get() as u16 - 1,
+            max_name_length: (T::MaxAgentNameLengthConstraint::get() as u16).saturating_sub(1),
             max_allowed_agents: 1,
             min_weight_control_fee: 1,
             min_staking_fee: 1,

--- a/pallets/permission0/src/ext/curator_impl.rs
+++ b/pallets/permission0/src/ext/curator_impl.rs
@@ -134,7 +134,7 @@ pub fn grant_curator_permission_impl<T: Config>(
     }
 
     let scope = PermissionScope::Curator(CuratorScope { flags, cooldown });
-    let permission_id = generate_permission_id::<T>(&grantor, &grantee, &scope);
+    let permission_id = generate_permission_id::<T>(&grantor, &grantee, &scope)?;
 
     let contract = PermissionContract {
         grantor,

--- a/pallets/permission0/tests/enforcement.rs
+++ b/pallets/permission0/tests/enforcement.rs
@@ -3,9 +3,10 @@
 use std::collections::BTreeMap;
 
 use pallet_permission0::permission::emission::StreamId;
-use pallet_permission0::EnforcementReferendum;
+use pallet_permission0::{EnforcementAuthority, EnforcementReferendum};
 use pallet_permission0_api::{generate_root_stream_id, Permission0EmissionApi};
 use polkadot_sdk::frame_support::{assert_err, traits::Currency};
+use polkadot_sdk::sp_core::bounded_vec;
 use polkadot_sdk::sp_runtime::Percent;
 use test_utils::*;
 
@@ -51,8 +52,10 @@ fn set_enforcement_authority_by_grantor() {
             pallet_permission0::Pallet::<Test>::set_enforcement_authority(
                 get_origin(grantee),
                 permission_id,
-                vec![controller],
-                1,
+                EnforcementAuthority::ControlledBy {
+                    controllers: bounded_vec![controller],
+                    required_votes: 1
+                }
             ),
             pallet_permission0::Error::<Test>::NotPermissionGrantor
         );
@@ -61,8 +64,10 @@ fn set_enforcement_authority_by_grantor() {
             pallet_permission0::Pallet::<Test>::set_enforcement_authority(
                 get_origin(controller),
                 permission_id,
-                vec![controller],
-                1,
+                EnforcementAuthority::ControlledBy {
+                    controllers: bounded_vec![controller],
+                    required_votes: 1
+                }
             ),
             pallet_permission0::Error::<Test>::NotPermissionGrantor
         );
@@ -71,8 +76,10 @@ fn set_enforcement_authority_by_grantor() {
             pallet_permission0::Pallet::<Test>::set_enforcement_authority(
                 get_origin(grantor),
                 permission_id,
-                vec![controller],
-                1,
+                EnforcementAuthority::ControlledBy {
+                    controllers: bounded_vec![controller],
+                    required_votes: 1
+                }
             )
         );
 

--- a/pallets/torus0/src/benchmarking.rs
+++ b/pallets/torus0/src/benchmarking.rs
@@ -33,7 +33,7 @@ mod benchmarks {
 
         register_test_agent::<T>(&agent, vec![1, 2, 3], vec![1, 2, 3], vec![1, 2, 3]);
 
-        let _ = <T::Currency>::deposit_creating(&staker, amount * 2);
+        let _ = <T::Currency>::deposit_creating(&staker, amount.saturating_mul(2));
 
         #[extrinsic_call]
         add_stake(RawOrigin::Signed(staker), agent, amount)
@@ -47,7 +47,7 @@ mod benchmarks {
         register_test_agent::<T>(&agent, vec![1, 2, 3], vec![1, 2, 3], vec![1, 2, 3]);
 
         let amount = MinAllowedStake::<T>::get();
-        let _ = <T::Currency>::deposit_creating(&staker, amount * 2);
+        let _ = <T::Currency>::deposit_creating(&staker, amount.saturating_mul(2));
         Pallet::<T>::force_set_stake(&staker, &agent, amount).expect("failed to add stake");
 
         #[extrinsic_call]
@@ -64,7 +64,7 @@ mod benchmarks {
         register_test_agent::<T>(&agent_b, vec![4, 5, 6], vec![4, 5, 6], vec![4, 5, 6]);
 
         let amount = MinAllowedStake::<T>::get();
-        let _ = <T::Currency>::deposit_creating(&staker, amount * 2);
+        let _ = <T::Currency>::deposit_creating(&staker, amount.saturating_mul(2));
         Pallet::<T>::force_set_stake(&staker, &agent_a, amount).expect("failed to add stake");
 
         #[extrinsic_call]
@@ -77,7 +77,7 @@ mod benchmarks {
         <T::Governance>::force_set_whitelisted(&agent);
 
         let burn = crate::Burn::<T>::get();
-        let _ = <T::Currency>::deposit_creating(&agent, burn * 2);
+        let _ = <T::Currency>::deposit_creating(&agent, burn.saturating_mul(2));
 
         let name = vec![1, 2, 3];
         let url = vec![1, 2, 3];

--- a/runtime/src/configs.rs
+++ b/runtime/src/configs.rs
@@ -87,7 +87,7 @@ impl frame_system::Config for Runtime {
 
 // --- Balances ---
 
-pub const EXISTENTIAL_DEPOSIT: u128 = 10_u128.pow(TOKEN_DECIMALS) / 10;
+pub const EXISTENTIAL_DEPOSIT: u128 = as_tors(1) / 10;
 
 impl pallet_balances::Config for Runtime {
     /// The means of storing the balances of an account
@@ -301,7 +301,7 @@ impl pallet_grandpa::Config for Runtime {
 // --- Torus ---
 
 const fn as_tors(val: u128) -> u128 {
-    val.saturating_add(10u128.pow(TOKEN_DECIMALS))
+    val.saturating_mul(10u128.pow(TOKEN_DECIMALS))
 }
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -38,7 +38,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("torus-runtime"),
     impl_name: create_runtime_str!("torus-runtime"),
     authoring_version: 1,
-    spec_version: 15,
+    spec_version: 16,
     impl_version: 1,
     apis: apis::RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/xtask/src/generate_spec.rs
+++ b/xtask/src/generate_spec.rs
@@ -42,20 +42,15 @@ fn generate_replica_spec(
     out: Option<PathBuf>,
     sudo: Option<String>,
 ) {
-    // Create Replica command
     let replica_cmd = flags::Replica {
         output: out,
         sudo,
         api_url: gen_replica.api_url.clone(),
     };
 
-    // Call the targetchain_spec function
     targetchain_spec(&replica_cmd);
-
-    // The file is already written by targetchain_spec, no need to write again
 }
 
-/// Function moved from build_spec.rs
 pub fn targetchain_spec(flags: &flags::Replica) -> Option<PathBuf> {
     let spec = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -86,7 +81,6 @@ pub fn targetchain_spec(flags: &flags::Replica) -> Option<PathBuf> {
     }
 }
 
-/// Sets the sudo key in the genesis state
 fn sudo(genesis: &mut Value, sudo: Option<&String>) {
     let key = key_name(b"Sudo", b"Key");
 
@@ -261,18 +255,15 @@ fn generate_new_spec(gen_new: &flags::GenNew, cmd: &flags::GenerateSpec) {
     customize_spec(&mut json, cmd);
 
     let serialized = serde_json::to_string_pretty(&json).expect("failed to generate spec file");
+    let Some(output_path) = &cmd.out else {
+        println!("{serialized}");
+        return;
+    };
 
-    match &cmd.out {
-        Some(output_path) => {
-            std::fs::write(output_path, serialized).expect("failed to write resulting spec file");
-        }
-        None => {
-            println!("{serialized}");
-        }
-    }
+    std::fs::write(output_path, serialized).expect("failed to write resulting spec file");
 }
 
-// Function to customize a spec file based on the provided flags
+/// Function to customize a spec file based on the provided flags
 pub fn customize_spec(json: &mut Value, cmd: &flags::GenerateSpec) {
     let patch = &mut json["genesis"]["runtimeGenesis"]["patch"];
 

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -86,7 +86,6 @@ pub(super) fn run(mut r: flags::Run) {
         .wait();
 }
 
-#[allow(dead_code)]
 pub mod ops {
     use std::{
         ffi::OsStr,
@@ -99,32 +98,10 @@ pub mod ops {
     #[macro_export]
     macro_rules! torus_node {
         ($($arg:expr),*) => {{
-            let mut cmd = std::process::Command::new("cargo");
-            cmd.args(["run", "--release", "--features", "testnet", "--package", "torus-node", "--"]);
+            let mut cmd = std::process::Command::new("./target/release/torus-node");
             $(cmd.arg($arg);)*
             cmd
         }};
-    }
-
-    pub fn build_chain_spec(chain_spec: &str) -> Command {
-        torus_node!(
-            "build-spec",
-            "--raw",
-            "--chain",
-            chain_spec,
-            "--disable-default-bootnode"
-        )
-    }
-
-    pub fn key_generate() -> Command {
-        torus_node!(
-            "key",
-            "generate",
-            "--scheme",
-            "sr25519",
-            "--output-type",
-            "json"
-        )
     }
 
     pub fn key_insert_cmd(
@@ -152,18 +129,6 @@ pub mod ops {
         .unwrap()
         .wait()
         .expect("failed to run key insert");
-    }
-
-    pub fn key_inspect_cmd(suri: &str) -> Command {
-        torus_node!(
-            "key",
-            "inspect",
-            "--scheme",
-            "ed25519",
-            "--output-type",
-            "json",
-            suri
-        )
     }
 
     pub fn key_inspect_node_cmd(key: &str) -> String {


### PR DESCRIPTION
This change serves more as a QoL update then everything.

The previous ID generation could allow for duplicate IDs in very specific cases, and that is now handled. When the enforcement authorities change, all ongoing enforcement votes for that permission are wiped. We cover more cases of input validation.
