### PR TITLE
refac(torus0/namespace): require agent prefix

### DIFF
--- a/pallets/permission0/src/ext/namespace_impl.rs
+++ b/pallets/permission0/src/ext/namespace_impl.rs
@@ -45,7 +45,8 @@ pub fn grant_namespace_permission_impl<T: Config>(
     let paths = paths
         .into_iter()
         .map(|path| {
-            let path = NamespacePath::new(&path).map_err(|_| Error::<T>::NamespacePathIsInvalid)?;
+            let path =
+                NamespacePath::new_agent(&path).map_err(|_| Error::<T>::NamespacePathIsInvalid)?;
             ensure!(
                 T::Torus::namespace_exists(&grantor, &path),
                 Error::<T>::NamespaceDoesNotExist

--- a/pallets/torus0/api/Cargo.toml
+++ b/pallets/torus0/api/Cargo.toml
@@ -18,4 +18,9 @@ try-runtime = ["polkadot-sdk/try-runtime"]
 [dependencies]
 codec = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"] }
-polkadot-sdk = { workspace = true, features = ["sp-runtime"] }
+polkadot-sdk = { workspace = true, features = [
+    "sp-api",
+    "sp-core",
+    "sp-runtime",
+    "sp-std",
+] }

--- a/pallets/torus0/src/benchmarking.rs
+++ b/pallets/torus0/src/benchmarking.rs
@@ -109,7 +109,6 @@ mod benchmarks {
 
         AgentUpdateCooldown::<T>::set(Default::default());
 
-        let name = vec![4, 5, 6];
         let url = vec![4, 5, 6];
         let metadata = Some(vec![4, 5, 6]);
         let staking_fee = Some(Percent::from_percent(10));
@@ -118,7 +117,6 @@ mod benchmarks {
         #[extrinsic_call]
         update_agent(
             RawOrigin::Signed(agent),
-            name,
             url,
             metadata,
             staking_fee,

--- a/pallets/torus0/src/namespace.rs
+++ b/pallets/torus0/src/namespace.rs
@@ -1,10 +1,14 @@
 use codec::{Decode, Encode, MaxEncodedLen};
+use pallet_governance_api::GovernanceApi;
 use polkadot_sdk::{
-    frame_support::{CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound},
-    frame_system::pallet_prelude::BlockNumberFor,
+    frame_support::{
+        traits::{ExistenceRequirement, ReservableCurrency},
+        CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound,
+    },
+    frame_system::{self, pallet_prelude::BlockNumberFor},
     sp_runtime::{
         traits::{One, Saturating, Zero},
-        FixedPointNumber, FixedU128,
+        DispatchResult, FixedPointNumber, FixedU128,
     },
 };
 use scale_info::TypeInfo;
@@ -15,6 +19,18 @@ pub use pallet_torus0_api::{
     NamespacePath, MAX_NAMESPACE_PATH_LENGTH, MAX_NAMESPACE_SEGMENTS, MAX_SEGMENT_LENGTH,
     NAMESPACE_SEPARATOR,
 };
+
+/// Describes the ownership of the namespace.
+#[derive(
+    Encode, Decode, CloneNoBound, DebugNoBound, PartialEqNoBound, EqNoBound, TypeInfo, MaxEncodedLen,
+)]
+#[scale_info(skip_type_params(T))]
+pub enum NamespaceOwnership<T: Config> {
+    /// Owned by the system. Used to register root-level namespaces, like agent.
+    System,
+    /// Owned by a SS58 account. Used to represent agent-owned namespaces.
+    Account(T::AccountId),
+}
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo, MaxEncodedLen, DebugNoBound)]
 #[scale_info(skip_type_params(T))]
@@ -74,10 +90,22 @@ impl<T: Config> NamespacePricingConfig<T> {
         Ok(base_fee.saturating_mul(multiplier).into_inner())
     }
 
-    /// Calculates the deposit needed to register a namespace.
+    /// Calculates the deposit needed to register a namespace. If a path with the agent prefix
+    /// is provided and contains more segments, the prefix (agent literal and agent name)
+    /// will be dropped.
     pub fn namespace_deposit(&self, path: &NamespacePath) -> BalanceOf<T> {
+        let segments: Vec<_> = path.segments().collect();
+        let mut segments = &segments[..];
+
+        if segments.first() == Some(&&b"agent"[..]) && segments.len() > 2 {
+            segments = segments.get(2..).unwrap_or(segments);
+        }
+
+        let bytes: u32 = segments.iter().map(|segment| segment.len() as u32).sum();
+        let dots = segments.len().saturating_sub(1) as u32;
+
         self.deposit_per_byte
-            .saturating_mul((path.as_bytes().len() as u32).into())
+            .saturating_mul(bytes.saturating_add(dots).into())
     }
 
     /// The fee midpoint.
@@ -114,13 +142,21 @@ pub struct NamespaceMetadata<T: Config> {
 }
 
 pub fn find_missing_paths<T: Config>(
-    owner: &T::AccountId,
+    owner: &NamespaceOwnership<T>,
     path: &NamespacePath,
 ) -> Vec<NamespacePath> {
     let mut paths_to_create = path.parents();
     paths_to_create.insert(0, path.clone());
 
-    for (i, segment) in paths_to_create.iter().enumerate().rev() {
+    let mut iter = paths_to_create.iter().enumerate().rev();
+    if matches!(owner, NamespaceOwnership::Account(_))
+        && path.root().as_ref().map(NamespacePath::as_bytes) == Some(&b"agent"[..])
+    {
+        // We drop the first segment, agent
+        let _ = iter.by_ref().next();
+    }
+
+    for (i, segment) in iter {
         if !Namespaces::<T>::contains_key(owner, segment) {
             return paths_to_create.get(..=i).unwrap_or_default().to_vec();
         }
@@ -131,7 +167,7 @@ pub fn find_missing_paths<T: Config>(
 
 /// Calculates the total cost for registering, (Fee, Deposit)
 pub fn calculate_cost<T: Config>(
-    owner: &T::AccountId,
+    owner: &NamespaceOwnership<T>,
     missing_paths: &[NamespacePath],
 ) -> Result<(BalanceOf<T>, BalanceOf<T>), DispatchError> {
     let current_count = NamespaceCount::<T>::get(owner);
@@ -150,4 +186,107 @@ pub fn calculate_cost<T: Config>(
     }
 
     Ok((total_fee, total_deposit))
+}
+
+pub fn create_namespace<T: Config>(
+    owner: NamespaceOwnership<T>,
+    path: NamespacePath,
+) -> DispatchResult {
+    #[allow(deprecated)]
+    create_namespace0(owner, path, true)
+}
+
+#[doc(hidden)]
+#[deprecated = "use crate_namespace instead"]
+pub(crate) fn create_namespace0<T: Config>(
+    owner: NamespaceOwnership<T>,
+    path: NamespacePath,
+    charge: bool,
+) -> DispatchResult {
+    ensure!(
+        !Namespaces::<T>::contains_key(&owner, &path),
+        Error::<T>::NamespaceAlreadyExists
+    );
+
+    let missing_paths = find_missing_paths::<T>(&owner, &path);
+
+    if charge {
+        let (total_fee, total_deposit) = calculate_cost::<T>(&owner, &missing_paths)?;
+
+        if let NamespaceOwnership::Account(owner) = &owner {
+            T::Currency::reserve(owner, total_deposit)?;
+
+            <T as crate::Config>::Currency::transfer(
+                owner,
+                &<T as crate::Config>::Governance::dao_treasury_address(),
+                total_fee,
+                ExistenceRequirement::AllowDeath,
+            )
+            .map_err(|_| crate::Error::<T>::NotEnoughBalanceToRegisterAgent)?;
+        }
+    }
+
+    let current_block = <frame_system::Pallet<T>>::block_number();
+    let pricing_config = crate::NamespacePricingConfig::<T>::get();
+
+    for path in missing_paths.iter() {
+        let deposit = if charge {
+            pricing_config.namespace_deposit(path)
+        } else {
+            Zero::zero()
+        };
+
+        let metadata = NamespaceMetadata {
+            created_at: current_block,
+            deposit,
+        };
+
+        Namespaces::<T>::insert(&owner, path, metadata);
+    }
+
+    NamespaceCount::<T>::mutate(&owner, |count| {
+        *count = count.saturating_add(missing_paths.len() as u32)
+    });
+
+    Pallet::<T>::deposit_event(Event::NamespaceCreated { owner, path });
+
+    Ok(())
+}
+
+pub fn delete_namespace<T: Config>(
+    owner: NamespaceOwnership<T>,
+    path: NamespacePath,
+) -> DispatchResult {
+    ensure!(
+        Namespaces::<T>::contains_key(&owner, &path),
+        Error::<T>::NamespaceNotFound
+    );
+
+    let mut total_deposit = BalanceOf::<T>::zero();
+    let namespaces_to_delete: Vec<_> = Namespaces::<T>::iter_prefix(&owner)
+        .filter_map(|(other, metadata)| {
+            if other == path || path.is_parent_of(&other) {
+                Some((other, metadata.deposit))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let deleted_count = namespaces_to_delete.len() as u32;
+
+    for (path_to_delete, deposit) in namespaces_to_delete {
+        total_deposit = total_deposit.saturating_add(deposit);
+        Namespaces::<T>::remove(&owner, &path_to_delete);
+    }
+
+    NamespaceCount::<T>::mutate(&owner, |count| *count = count.saturating_sub(deleted_count));
+
+    if let NamespaceOwnership::Account(owner) = &owner {
+        T::Currency::unreserve(owner, total_deposit);
+    }
+
+    Pallet::<T>::deposit_event(Event::NamespaceDeleted { owner, path });
+
+    Ok(())
 }

--- a/pallets/torus0/tests/agent.rs
+++ b/pallets/torus0/tests/agent.rs
@@ -18,9 +18,9 @@ fn register_correctly() {
         let agent_id = 0;
         let allocator_id = 1;
 
-        let name = "idk://agent".as_bytes().to_vec();
-        let url = "idk://agent".as_bytes().to_vec();
-        let metadata = "idk://agent".as_bytes().to_vec();
+        let name = b"agent".to_vec();
+        let url = b"idk://agent".to_vec();
+        let metadata = b"idk://agent".to_vec();
 
         // Register allocator
         Agents::<Test>::set(
@@ -86,9 +86,9 @@ fn register_correctly() {
 fn register_without_being_whitelisted() {
     test_utils::new_test_ext().execute_with(|| {
         let agent = 0;
-        let name = "agent".as_bytes().to_vec();
-        let url = "idk://agent".as_bytes().to_vec();
-        let metadata = "idk://agent".as_bytes().to_vec();
+        let name = b"agent".to_vec();
+        let url = b"idk://agent".to_vec();
+        let metadata = b"idk://agent".to_vec();
 
         assert_ok!(pallet_torus0::agent::register::<Test>(
             agent,
@@ -108,9 +108,9 @@ fn register_without_being_whitelisted() {
 fn register_without_enough_balance() {
     test_utils::new_test_ext().execute_with(|| {
         let agent = 0;
-        let name = "agent".as_bytes().to_vec();
-        let url = "idk://agent".as_bytes().to_vec();
-        let metadata = "idk://agent".as_bytes().to_vec();
+        let name = b"agent".to_vec();
+        let url = b"idk://agent".to_vec();
+        let metadata = b"idk://agent".to_vec();
 
         Burn::<Test>::set(100);
 
@@ -133,8 +133,8 @@ fn register_without_enough_balance() {
 fn register_fail_name_validation() {
     test_utils::new_test_ext().execute_with(|| {
         let agent = 0;
-        let url = "idk://agent".as_bytes().to_vec();
-        let metadata = "idk://agent".as_bytes().to_vec();
+        let url = b"idk://agent".to_vec();
+        let metadata = b"idk://agent".to_vec();
 
         assert_ok!(pallet_governance::whitelist::add_to_whitelist::<Test>(
             agent
@@ -148,7 +148,7 @@ fn register_fail_name_validation() {
                 url.clone(),
                 metadata.clone(),
             ),
-            pallet_torus0::Error::<Test>::AgentNameTooShort
+            pallet_torus0::Error::<Test>::InvalidNamespacePath
         );
 
         assert_err!(
@@ -161,7 +161,7 @@ fn register_fail_name_validation() {
                 url.clone(),
                 metadata.clone(),
             ),
-            pallet_torus0::Error::<Test>::AgentNameTooLong
+            pallet_torus0::Error::<Test>::InvalidNamespacePath
         );
 
         assert_err!(
@@ -172,7 +172,7 @@ fn register_fail_name_validation() {
                 url.clone(),
                 metadata.clone(),
             ),
-            pallet_torus0::Error::<Test>::InvalidAgentName
+            pallet_torus0::Error::<Test>::InvalidNamespacePath
         );
     });
 }
@@ -181,8 +181,8 @@ fn register_fail_name_validation() {
 fn register_fail_url_validation() {
     test_utils::new_test_ext().execute_with(|| {
         let agent = 0;
-        let name = "agent".as_bytes().to_vec();
-        let metadata = "idk://agent".as_bytes().to_vec();
+        let name = b"agent".to_vec();
+        let metadata = b"idk://agent".to_vec();
 
         assert_ok!(pallet_governance::whitelist::add_to_whitelist::<Test>(
             agent
@@ -229,8 +229,8 @@ fn register_fail_url_validation() {
 fn register_fail_metadata_validation() {
     test_utils::new_test_ext().execute_with(|| {
         let agent = 0;
-        let name = "agent".as_bytes().to_vec();
-        let url = "idk://agent".as_bytes().to_vec();
+        let name = b"agent".to_vec();
+        let url = b"idk://agent".to_vec();
 
         assert_ok!(pallet_governance::whitelist::add_to_whitelist::<Test>(
             agent
@@ -279,9 +279,9 @@ fn register_fail_metadata_validation() {
 fn register_more_than_allowed_registrations_per_block() {
     test_utils::new_test_ext().execute_with(|| {
         let agent = 0;
-        let name = "agent".as_bytes().to_vec();
-        let url = "idk://agent".as_bytes().to_vec();
-        let metadata = "idk://agent".as_bytes().to_vec();
+        let name = b"agent".to_vec();
+        let url = b"idk://agent".to_vec();
+        let metadata = b"idk://agent".to_vec();
 
         pallet_torus0::MaxRegistrationsPerBlock::<Test>::set(0);
 
@@ -308,9 +308,9 @@ fn register_more_than_allowed_registrations_per_block() {
 fn register_more_than_registrations_per_interval() {
     test_utils::new_test_ext().execute_with(|| {
         let agent = 0;
-        let name = "agent".as_bytes().to_vec();
-        let url = "idk://agent".as_bytes().to_vec();
-        let metadata = "idk://agent".as_bytes().to_vec();
+        let name = b"agent".to_vec();
+        let url = b"idk://agent".to_vec();
+        let metadata = b"idk://agent".to_vec();
 
         pallet_torus0::BurnConfig::<Test>::mutate(|config| {
             config.max_registrations_per_interval = 0;
@@ -339,9 +339,9 @@ fn register_more_than_registrations_per_interval() {
 fn unregister_correctly() {
     test_utils::new_test_ext().execute_with(|| {
         let agent = 0;
-        let name = "agent".as_bytes().to_vec();
-        let url = "idk://agent".as_bytes().to_vec();
-        let metadata = "idk://agent".as_bytes().to_vec();
+        let name = b"agent".to_vec();
+        let url = b"idk://agent".to_vec();
+        let metadata = b"idk://agent".to_vec();
 
         assert_ok!(pallet_governance::whitelist::add_to_whitelist::<Test>(
             agent
@@ -367,9 +367,9 @@ fn unregister_correctly() {
 fn unregister_twice() {
     test_utils::new_test_ext().execute_with(|| {
         let agent = 0;
-        let name = "agent".as_bytes().to_vec();
-        let url = "idk://agent".as_bytes().to_vec();
-        let metadata = "idk://agent".as_bytes().to_vec();
+        let name = b"agent".to_vec();
+        let url = b"idk://agent".to_vec();
+        let metadata = b"idk://agent".to_vec();
 
         assert_ok!(pallet_governance::whitelist::add_to_whitelist::<Test>(
             agent
@@ -401,19 +401,12 @@ fn update_correctly() {
         clear_cooldown();
 
         let agent = 0;
-        let name = "agent".as_bytes().to_vec();
-        let url = "idk://agent".as_bytes().to_vec();
-        let metadata = "idk://agent".as_bytes().to_vec();
+        let name = b"agent".to_vec();
+        let url = b"idk://agent".to_vec();
+        let metadata = b"idk://agent".to_vec();
 
         assert_err!(
-            pallet_torus0::agent::update::<Test>(
-                agent,
-                b"".to_vec(),
-                b"".to_vec(),
-                None,
-                None,
-                None,
-            ),
+            pallet_torus0::agent::update::<Test>(agent, b"".to_vec(), None, None, None,),
             Error::<Test>::AgentDoesNotExist
         );
 
@@ -429,9 +422,8 @@ fn update_correctly() {
             metadata,
         ));
 
-        let new_name = "new-agent".as_bytes().to_vec();
-        let new_url = "new-idk://agent".as_bytes().to_vec();
-        let new_metadata = "new-idk://agent".as_bytes().to_vec();
+        let new_url = b"new-idk://agent".to_vec();
+        let new_metadata = b"new-idk://agent".to_vec();
 
         let constraints = pallet_torus0::FeeConstraints::<Test>::get();
         let staking_fee = constraints.min_staking_fee;
@@ -439,7 +431,6 @@ fn update_correctly() {
 
         assert_ok!(pallet_torus0::Pallet::<Test>::update_agent(
             get_origin(agent),
-            new_name.clone(),
             new_url.clone(),
             Some(new_metadata.clone()),
             Some(staking_fee),
@@ -448,7 +439,6 @@ fn update_correctly() {
 
         let agent = Agents::<Test>::get(agent).expect("it should exists");
 
-        assert_eq!(agent.name.to_vec(), new_name);
         assert_eq!(agent.url.to_vec(), new_url);
         assert_eq!(agent.metadata.to_vec(), new_metadata);
         assert_eq!(agent.fees.staking_fee, staking_fee);
@@ -462,9 +452,9 @@ fn update_with_zero_staking_fee() {
         clear_cooldown();
 
         let agent = 0;
-        let name = "agent".as_bytes().to_vec();
-        let url = "idk://agent".as_bytes().to_vec();
-        let metadata = "idk://agent".as_bytes().to_vec();
+        let name = b"agent".to_vec();
+        let url = b"idk://agent".to_vec();
+        let metadata = b"idk://agent".to_vec();
 
         assert_ok!(pallet_governance::whitelist::add_to_whitelist::<Test>(
             agent
@@ -478,9 +468,8 @@ fn update_with_zero_staking_fee() {
             metadata.clone(),
         ));
 
-        let new_name = "new-agent".as_bytes().to_vec();
-        let new_url = "new-idk://agent".as_bytes().to_vec();
-        let new_metadata = "new-idk://agent".as_bytes().to_vec();
+        let new_url = b"new-idk://agent".to_vec();
+        let new_metadata = b"new-idk://agent".to_vec();
 
         let constraints = pallet_torus0::FeeConstraints::<Test>::get();
         let staking_fee = constraints.min_staking_fee;
@@ -489,7 +478,6 @@ fn update_with_zero_staking_fee() {
         assert_err!(
             pallet_torus0::agent::update::<Test>(
                 agent,
-                new_name.clone(),
                 new_url.clone(),
                 Some(new_metadata.clone()),
                 Some(Percent::zero()),
@@ -514,9 +502,9 @@ fn update_with_zero_weight_control_fee() {
         clear_cooldown();
 
         let agent = 0;
-        let name = "agent".as_bytes().to_vec();
-        let url = "idk://agent".as_bytes().to_vec();
-        let metadata = "idk://agent".as_bytes().to_vec();
+        let name = b"agent".to_vec();
+        let url = b"idk://agent".to_vec();
+        let metadata = b"idk://agent".to_vec();
 
         assert_ok!(pallet_governance::whitelist::add_to_whitelist::<Test>(
             agent
@@ -530,9 +518,8 @@ fn update_with_zero_weight_control_fee() {
             metadata.clone(),
         ));
 
-        let new_name = "new-agent".as_bytes().to_vec();
-        let new_url = "new-idk://agent".as_bytes().to_vec();
-        let new_metadata = "new-idk://agent".as_bytes().to_vec();
+        let new_url = b"new-idk://agent".to_vec();
+        let new_metadata = b"new-idk://agent".to_vec();
 
         let constraints = pallet_torus0::FeeConstraints::<Test>::get();
         let staking_fee = constraints.min_staking_fee;
@@ -541,7 +528,6 @@ fn update_with_zero_weight_control_fee() {
         assert_err!(
             pallet_torus0::agent::update::<Test>(
                 agent,
-                new_name.clone(),
                 new_url.clone(),
                 Some(new_metadata.clone()),
                 Some(staking_fee),
@@ -564,19 +550,12 @@ fn update_with_zero_weight_control_fee() {
 fn fails_updating_whitout_waiting_cooldown() {
     test_utils::new_test_ext().execute_with(|| {
         let agent = 0;
-        let name = "agent".as_bytes().to_vec();
-        let url = "idk://agent".as_bytes().to_vec();
-        let metadata = "idk://agent".as_bytes().to_vec();
+        let name = b"agent".to_vec();
+        let url = b"idk://agent".to_vec();
+        let metadata = b"idk://agent".to_vec();
 
         assert_err!(
-            pallet_torus0::agent::update::<Test>(
-                agent,
-                b"".to_vec(),
-                b"".to_vec(),
-                None,
-                None,
-                None,
-            ),
+            pallet_torus0::agent::update::<Test>(agent, b"".to_vec(), None, None, None,),
             Error::<Test>::AgentDoesNotExist
         );
 
@@ -592,9 +571,8 @@ fn fails_updating_whitout_waiting_cooldown() {
             metadata,
         ));
 
-        let new_name = "new-agent".as_bytes().to_vec();
-        let new_url = "new-idk://agent".as_bytes().to_vec();
-        let new_metadata = "new-idk://agent".as_bytes().to_vec();
+        let new_url = b"new-idk://agent".to_vec();
+        let new_metadata = b"new-idk://agent".to_vec();
 
         let constraints = pallet_torus0::FeeConstraints::<Test>::get();
         let staking_fee = constraints.min_staking_fee;
@@ -603,7 +581,6 @@ fn fails_updating_whitout_waiting_cooldown() {
         assert_err!(
             pallet_torus0::Pallet::<Test>::update_agent(
                 get_origin(agent),
-                new_name.clone(),
                 new_url.clone(),
                 Some(new_metadata.clone()),
                 Some(staking_fee),
@@ -616,7 +593,6 @@ fn fails_updating_whitout_waiting_cooldown() {
 
         assert_ok!(pallet_torus0::Pallet::<Test>::update_agent(
             get_origin(agent),
-            new_name.clone(),
             new_url.clone(),
             Some(new_metadata.clone()),
             Some(staking_fee),
@@ -626,7 +602,6 @@ fn fails_updating_whitout_waiting_cooldown() {
         assert_err!(
             pallet_torus0::Pallet::<Test>::update_agent(
                 get_origin(agent),
-                new_name.clone(),
                 new_url.clone(),
                 Some(new_metadata.clone()),
                 Some(staking_fee),

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -478,10 +478,11 @@ impl_runtime_apis! {
             use pallet_torus0_api::NamespacePath;
 
             let namespace_path =
-                NamespacePath::new(&path).map_err(|_| pallet_torus0::Error::<Runtime>::InvalidNamespacePath)?;
+                NamespacePath::new_agent(&path).map_err(|_| pallet_torus0::Error::<Runtime>::InvalidNamespacePath)?;
 
-            let missing_paths = namespace::find_missing_paths::<Runtime>(&account_id, &namespace_path);
-            namespace::calculate_cost::<Runtime>(&account_id, &missing_paths)
+                let owner = namespace::NamespaceOwnership::Account(account_id);
+            let missing_paths = namespace::find_missing_paths::<Runtime>(&owner, &namespace_path);
+            namespace::calculate_cost::<Runtime>(&owner, &missing_paths)
         }
     }
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -94,12 +94,12 @@ parameter_types! {
     pub const DefaultDividendsParticipationWeight: Percent = Percent::from_parts(40);
 
     pub DefaultNamespacePricingConfig: pallet_torus0::namespace::NamespacePricingConfig<Test> = pallet_torus0::namespace::NamespacePricingConfig {
-        base_fee: as_tors(5),
-        deposit_per_byte: as_tors(5),
+        base_fee: as_tors(0),
+        deposit_per_byte: as_tors(0),
 
         count_midpoint: 20,
         fee_steepness: Percent::from_percent(20),
-        max_fee_multiplier: 5,
+        max_fee_multiplier: 0,
     };
 }
 


### PR DESCRIPTION
This change makes the "agent.<name>" prefix required in order to facilitate future integrations. This change, though, makes the agent name immutable. Now, upon registration, the agent name will be automatically registered to the namespace.

Closes CHAIN-102.