### PR TITLE
fix(torus0/stake): refund stake before clearing map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,15 @@ resolver = "2"
 authors = ["Renlabs <contact@renlabs.dev>"]
 edition = "2021"
 
+[workspace.lints.clippy]
+all = "deny"
+arithmetic_side_effects = "deny"
+indexing_slicing = "deny"
+panicking_unwrap = "deny"
+out_of_bounds_indexing = "deny"
+match_bool = "deny"
+infinite_loop = "deny"
+
 [workspace.dependencies]
 
 # Local

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -152,6 +152,7 @@ type InherentDataProviders = (
     fp_dynamic_fee::InherentDataProvider,
 );
 
+#[allow(clippy::type_complexity)]
 fn aura_data_provider(
     slot_duration: sp_consensus_aura::SlotDuration,
     eth_config: &EthConfiguration,

--- a/pallets/emission0/Cargo.toml
+++ b/pallets/emission0/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT-0"
 authors.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["std"]
 std = [

--- a/pallets/emission0/tests/distribution.rs
+++ b/pallets/emission0/tests/distribution.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::array::from_fn;
 
 use pallet_emission0::{

--- a/pallets/governance/Cargo.toml
+++ b/pallets/governance/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT-0"
 authors.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["std"]
 std = [

--- a/pallets/governance/src/application.rs
+++ b/pallets/governance/src/application.rs
@@ -91,7 +91,7 @@ pub fn submit_application<T: crate::Config>(
             .ok()
             .expect("blockchain will not exceed 2^64 blocks; QED.");
 
-    let expires_at = current_block + config.agent_application_expiration;
+    let expires_at = current_block.saturating_add(config.agent_application_expiration);
 
     let next_id = AgentApplications::<T>::iter()
         .count()

--- a/pallets/governance/src/proposal.rs
+++ b/pallets/governance/src/proposal.rs
@@ -46,7 +46,7 @@ impl<T: crate::Config> Proposal<T> {
 
     pub fn execution_block(&self) -> Block {
         match self.data {
-            ProposalData::Emission { .. } => self.creation_block + 21_600,
+            ProposalData::Emission { .. } => self.creation_block.saturating_add(21_600),
             _ => self.expiration_block,
         }
     }
@@ -402,7 +402,7 @@ fn add_proposal<T: crate::Config>(
     let proposal = Proposal::<T> {
         id: proposal_id,
         proposer,
-        expiration_block: current_block + config.proposal_expiration,
+        expiration_block: current_block.saturating_add(config.proposal_expiration),
         data,
         status: ProposalStatus::Open {
             votes_for: BoundedBTreeSet::new(),

--- a/pallets/governance/tests/voting.rs
+++ b/pallets/governance/tests/voting.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arithmetic_side_effects)]
+
 use pallet_emission0::PendingEmission;
 use pallet_governance::{
     config::GovernanceConfiguration,

--- a/pallets/torus0/Cargo.toml
+++ b/pallets/torus0/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT-0"
 authors.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["std"]
 std = [

--- a/pallets/torus0/src/agent.rs
+++ b/pallets/torus0/src/agent.rs
@@ -131,8 +131,9 @@ pub fn unregister<T: crate::Config>(agent_key: AccountIdOf<T>) -> DispatchResult
         crate::Error::<T>::AgentDoesNotExist
     );
 
-    crate::Agents::<T>::remove(&agent_key);
     crate::stake::clear_key::<T>(&agent_key)?;
+
+    crate::Agents::<T>::remove(&agent_key);
 
     crate::Pallet::<T>::deposit_event(crate::Event::<T>::AgentUnregistered(agent_key));
 

--- a/pallets/torus0/src/lib.rs
+++ b/pallets/torus0/src/lib.rs
@@ -27,7 +27,7 @@ use scale_info::prelude::vec::Vec;
 
 #[frame::pallet]
 pub mod pallet {
-    const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
     use frame::prelude::BlockNumberFor;
     use pallet_emission0_api::Emission0Api;

--- a/pallets/torus0/src/migrations.rs
+++ b/pallets/torus0/src/migrations.rs
@@ -41,3 +41,79 @@ pub mod v2 {
         }
     }
 }
+
+pub mod v3 {
+    use super::*;
+    use polkadot_sdk::{
+        frame_support::traits::Currency,
+        sp_tracing::{error, info},
+    };
+
+    pub type Migration<T, W> = VersionedMigration<2, 3, MigrateToV3<T>, Pallet<T>, W>;
+    pub struct MigrateToV3<T>(core::marker::PhantomData<T>);
+
+    impl<T: Config> UncheckedOnRuntimeUpgrade for MigrateToV3<T> {
+        fn on_runtime_upgrade() -> Weight {
+            refund_imbalance::<T>();
+
+            Weight::default()
+        }
+    }
+
+    /// A bug on the staking code cleared the stake maps before
+    /// refunding the stake. Because the total stake was not updated in time,
+    /// the imbalance refers exactly to the amount that needs to be refunded.
+    ///
+    /// This way we safely avoid minting new tokens.
+    fn refund_imbalance<T: Config>() {
+        fn ss58_to_account_id<T: Config>(ss58_address: &str) -> Option<T::AccountId> {
+            use codec::{Decode, Encode};
+            use polkadot_sdk::{sp_application_crypto::Ss58Codec, sp_runtime::AccountId32};
+
+            let account_id = AccountId32::from_ss58check(ss58_address).ok()?;
+            T::AccountId::decode(&mut account_id.encode().as_slice()).ok()
+        }
+
+        let account = "5Ef9VXKCmhXCWGdmqm6bm3eVf6WWckd4P1NZTeZLCTJBoduL";
+        let Some(account) = ss58_to_account_id::<T>(account) else {
+            error!("invalid account {account}");
+            return;
+        };
+
+        let total_stake = crate::TotalStake::<T>::get();
+
+        let mut sum_staking_to = 0u128;
+        for (_, _, stake) in crate::StakingTo::<T>::iter() {
+            sum_staking_to = sum_staking_to.saturating_add(stake);
+        }
+
+        let mut sum_staked_by = 0u128;
+        for (_, _, stake) in crate::StakedBy::<T>::iter() {
+            sum_staked_by = sum_staked_by.saturating_add(stake);
+        }
+
+        if sum_staking_to != sum_staked_by {
+            error!("imbalance between StakingTo ({sum_staking_to}) and StakedBy ({sum_staked_by})");
+            return;
+        }
+
+        let imbalance = total_stake.saturating_sub(sum_staking_to);
+        if imbalance == 0 {
+            error!("no imbalance between TotalStake and stake maps");
+        }
+
+        info!("imbalance between TotalStake - sum(stake) = {imbalance}");
+
+        let _ = T::Currency::deposit_creating(&account, imbalance);
+        crate::TotalStake::<T>::mutate(|total_stake| {
+            *total_stake = total_stake.saturating_sub(imbalance);
+        });
+
+        let new_total_stake = crate::TotalStake::<T>::get();
+        if new_total_stake == sum_staking_to {
+            info!("imbalance refunded to {account:?}, {new_total_stake} == {sum_staking_to}");
+        } else {
+            error!("imbalance remained, {new_total_stake} != {sum_staking_to}");
+        }
+    }
+}

--- a/pallets/torus0/src/migrations.rs
+++ b/pallets/torus0/src/migrations.rs
@@ -100,6 +100,7 @@ pub mod v3 {
         let imbalance = total_stake.saturating_sub(sum_staking_to);
         if imbalance == 0 {
             error!("no imbalance between TotalStake and stake maps");
+            return;
         }
 
         info!("imbalance between TotalStake - sum(stake) = {imbalance}");
@@ -110,10 +111,11 @@ pub mod v3 {
         });
 
         let new_total_stake = crate::TotalStake::<T>::get();
-        if new_total_stake == sum_staking_to {
-            info!("imbalance refunded to {account:?}, {new_total_stake} == {sum_staking_to}");
-        } else {
+        if new_total_stake != sum_staking_to {
             error!("imbalance remained, {new_total_stake} != {sum_staking_to}");
-        }
+            return;
+        };
+
+        info!("imbalance refunded to {account:?}, {new_total_stake} == {sum_staking_to}");
     }
 }

--- a/pallets/torus0/src/stake.rs
+++ b/pallets/torus0/src/stake.rs
@@ -1,10 +1,14 @@
-use polkadot_sdk::sp_std::{collections::btree_map::BTreeMap, vec::Vec};
-use polkadot_sdk::sp_tracing::error;
+use polkadot_sdk::{
+    frame_support::{
+        dispatch::DispatchResult,
+        ensure,
+        traits::{Currency, ExistenceRequirement, Imbalance, WithdrawReasons},
+    },
+    sp_std::{collections::btree_map::BTreeMap, vec::Vec},
+};
 
 use crate::agent;
 use crate::{AccountIdOf, BalanceOf};
-use polkadot_sdk::frame_support::traits::{Currency, ExistenceRequirement, WithdrawReasons};
-use polkadot_sdk::frame_support::{dispatch::DispatchResult, ensure};
 
 pub fn add_stake<T: crate::Config>(
     staker: AccountIdOf<T>,
@@ -40,42 +44,62 @@ pub fn add_stake<T: crate::Config>(
 }
 
 pub fn remove_stake<T: crate::Config>(
-    key: AccountIdOf<T>,
-    agent_key: AccountIdOf<T>,
+    staker: AccountIdOf<T>,
+    staked: AccountIdOf<T>,
     amount: BalanceOf<T>,
 ) -> DispatchResult {
     ensure!(
-        amount >= crate::MinAllowedStake::<T>::get(),
-        crate::Error::<T>::StakeTooSmall
-    );
-
-    ensure!(
-        agent::exists::<T>(&agent_key),
+        agent::exists::<T>(&staked),
         crate::Error::<T>::AgentDoesNotExist
     );
 
     ensure!(
-        crate::StakingTo::<T>::get(&key, &agent_key).unwrap_or(0) >= amount,
+        crate::StakingTo::<T>::get(&staker, &staked).unwrap_or(0) >= amount,
         crate::Error::<T>::NotEnoughStakeToWithdraw
     );
 
-    crate::StakingTo::<T>::mutate(&key, &agent_key, |stake| {
-        *stake = Some(stake.unwrap_or(0).saturating_sub(amount))
-    });
-
-    crate::StakedBy::<T>::mutate(&agent_key, &key, |stake| {
-        *stake = Some(stake.unwrap_or(0).saturating_sub(amount))
-    });
-
-    crate::TotalStake::<T>::mutate(|total_stake| *total_stake = total_stake.saturating_sub(amount));
-
-    let _ = <T as crate::Config>::Currency::deposit_creating(&key, amount);
-
-    crate::Pallet::<T>::deposit_event(crate::Event::<T>::StakeRemoved(key, agent_key, amount));
+    remove_stake0::<T>(staker, staked, amount, true);
 
     Ok(())
 }
 
+fn remove_stake0<T: crate::Config>(
+    staker: AccountIdOf<T>,
+    staked: AccountIdOf<T>,
+    amount: BalanceOf<T>,
+    keep: bool,
+) {
+    let Some(stake) = crate::StakingTo::<T>::get(&staker, &staked) else {
+        return;
+    };
+
+    let mut stake = T::Currency::issue(stake);
+    let retrieved = stake.extract(amount);
+
+    let new_stake = if keep || stake.peek() > 0 {
+        Some(stake.peek())
+    } else {
+        None
+    };
+
+    crate::StakingTo::<T>::set(&staker, &staked, new_stake);
+    crate::StakedBy::<T>::set(&staked, &staker, new_stake);
+    crate::TotalStake::<T>::mutate(|total_stake| {
+        *total_stake = total_stake.saturating_sub(retrieved.peek())
+    });
+
+    let retrieved_value = retrieved.peek();
+    <T as crate::Config>::Currency::resolve_creating(&staker, retrieved);
+
+    crate::Pallet::<T>::deposit_event(crate::Event::<T>::StakeRemoved(
+        staker,
+        staked,
+        retrieved_value,
+    ));
+}
+
+/// Transfers stake from an account to another (see [`remove_stake`],
+/// [`add_stake`]).
 pub fn transfer_stake<T: crate::Config>(
     staker: AccountIdOf<T>,
     old_staked: AccountIdOf<T>,
@@ -88,16 +112,10 @@ pub fn transfer_stake<T: crate::Config>(
 }
 
 pub(crate) fn clear_key<T: crate::Config>(key: &AccountIdOf<T>) -> DispatchResult {
-    for (staker, staked, amount) in crate::StakingTo::<T>::iter() {
+    let stakes: Vec<_> = crate::StakingTo::<T>::iter().collect();
+    for (staker, staked, amount) in stakes {
         if &staker == key || &staked == key {
-            crate::StakingTo::<T>::remove(&staker, &staked);
-            crate::StakedBy::<T>::remove(&staked, &staker);
-            if let Err(err) = remove_stake::<T>(staker.clone(), staked.clone(), amount) {
-                error!(
-                    "could not remove stake from {:?} to {:?}: {err:?}",
-                    staker, staked
-                )
-            }
+            remove_stake0::<T>(staker, staked, amount, false);
         }
     }
 

--- a/pallets/torus0/tests/stake.rs
+++ b/pallets/torus0/tests/stake.rs
@@ -1,6 +1,6 @@
 use pallet_torus0::{Error, MinAllowedStake, StakedBy, StakingTo, TotalStake};
 use polkadot_sdk::frame_support::{assert_err, traits::Currency};
-use test_utils::{assert_ok, get_origin, pallet_governance, Balances, Test};
+use test_utils::{assert_ok, get_origin, pallet_governance, to_nano, Balances, Test};
 
 #[test]
 fn add_stake_correctly() {
@@ -130,84 +130,52 @@ fn remove_stake_correctly() {
 }
 
 #[test]
-fn remove_stake_with_less_than_required_amount() {
-    test_utils::new_test_ext().execute_with(|| {
-        let from = 0;
-        let to = 1;
-        let stake_to_add_and_remove = MinAllowedStake::<Test>::get();
-        let total_balance = stake_to_add_and_remove * 2;
-
-        assert_ok!(pallet_governance::whitelist::add_to_whitelist::<Test>(to));
-        assert_ok!(pallet_torus0::agent::register::<Test>(
-            to,
-            to,
-            "to".as_bytes().to_vec(),
-            "to://idk".as_bytes().to_vec(),
-            "idk".as_bytes().to_vec()
-        ));
-
-        let _ = Balances::deposit_creating(&from, total_balance);
-        assert_eq!(Balances::total_balance(&to), 0);
-
-        assert_ok!(pallet_torus0::stake::add_stake::<Test>(
-            from,
-            to,
-            stake_to_add_and_remove
-        ));
-
-        assert_err!(
-            pallet_torus0::stake::remove_stake::<Test>(from, to, stake_to_add_and_remove - 1),
-            Error::<Test>::StakeTooSmall,
-        );
-
-        assert_eq!(Balances::total_balance(&from), stake_to_add_and_remove);
-        assert_eq!(
-            StakingTo::<Test>::get(from, to),
-            Some(stake_to_add_and_remove)
-        );
-        assert_eq!(
-            StakedBy::<Test>::get(to, from),
-            Some(stake_to_add_and_remove)
-        );
-        assert_eq!(TotalStake::<Test>::get(), stake_to_add_and_remove);
-    });
-}
-
-#[test]
 fn remove_stake_with_unregistered_agent() {
     test_utils::new_test_ext().execute_with(|| {
         let from = 0;
         let to = 1;
-        let stake_to_add_and_remove = MinAllowedStake::<Test>::get();
-        let total_balance = stake_to_add_and_remove * 2;
+
+        let stake = to_nano(500);
+        let total_balance = stake * 2;
 
         assert_ok!(pallet_governance::whitelist::add_to_whitelist::<Test>(to));
-        assert_ok!(pallet_torus0::agent::register::<Test>(
+        assert_ok!(pallet_torus0::Pallet::<Test>::register_agent(
+            get_origin(to),
             to,
-            to,
-            "to".as_bytes().to_vec(),
-            "to://idk".as_bytes().to_vec(),
-            "idk".as_bytes().to_vec()
+            b"to".to_vec(),
+            b"to://idk".to_vec(),
+            b"idk".to_vec()
         ));
 
         let _ = Balances::deposit_creating(&from, total_balance);
 
+        assert_eq!(Balances::total_balance(&from), total_balance);
         assert_eq!(Balances::total_balance(&to), 0);
-        assert_ok!(pallet_torus0::stake::add_stake::<Test>(
-            from,
+
+        assert_ok!(pallet_torus0::Pallet::<Test>::add_stake(
+            get_origin(from),
             to,
-            stake_to_add_and_remove,
+            stake,
         ));
-        assert_ok!(pallet_torus0::agent::unregister::<Test>(to));
+
+        assert_eq!(Balances::total_balance(&from), total_balance / 2);
+
+        assert_eq!(TotalStake::<Test>::get(), stake);
+        assert_eq!(StakingTo::<Test>::get(from, to), Some(stake));
+        assert_eq!(StakedBy::<Test>::get(to, from), Some(stake));
+
+        assert_ok!(pallet_torus0::Pallet::<Test>::unregister_agent(get_origin(
+            to
+        )));
 
         assert_err!(
-            pallet_torus0::stake::remove_stake::<Test>(from, to, stake_to_add_and_remove),
+            pallet_torus0::Pallet::<Test>::remove_stake(get_origin(from), to, stake),
             Error::<Test>::AgentDoesNotExist,
         );
 
-        assert_eq!(Balances::total_balance(&from), stake_to_add_and_remove);
+        assert_eq!(Balances::total_balance(&from), total_balance);
         assert_eq!(StakingTo::<Test>::get(from, to), None);
         assert_eq!(StakedBy::<Test>::get(to, from), None);
-        assert_eq!(TotalStake::<Test>::get(), stake_to_add_and_remove);
+        assert_eq!(TotalStake::<Test>::get(), 0);
     });
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT-0"
 authors.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["std"]
 std = [

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -442,7 +442,7 @@ impl_runtime_apis! {
                 let _ = RuntimeExecutive::apply_extrinsic(ext);
             }
 
-            Ethereum::on_finalize(System::block_number() + 1);
+            Ethereum::on_finalize(System::block_number().saturating_add(1));
 
             (
                 pallet_ethereum::CurrentBlock::<Runtime>::get(),

--- a/runtime/src/configs.rs
+++ b/runtime/src/configs.rs
@@ -134,11 +134,11 @@ impl pallet_sudo::Config for Runtime {
 
 parameter_types! {
     // Base: 1 token + (88 bytes * 0.01 token)
-    pub const DepositBase: Balance = 10u128.saturating_pow(TOKEN_DECIMALS)  // 1 token
-        + (88 * 10u128.saturating_pow(TOKEN_DECIMALS - 2));  // 0.01 token per byte
+    pub const DepositBase: Balance = 10u128.saturating_pow(TOKEN_DECIMALS) // 1 token
+        .saturating_add(88u128.saturating_mul(10u128.saturating_pow(TOKEN_DECIMALS.saturating_sub(2))));  // 0.01 token per byte
     // Factor: (32 bytes * 0.01 token)
     pub const DepositFactor: Balance =
-        32 * 10u128.saturating_pow(TOKEN_DECIMALS - 2);  // 0.01 token per byte
+        32u128.saturating_mul(10u128.saturating_pow(TOKEN_DECIMALS.saturating_sub(2)));  // 0.01 token per byte
 }
 
 impl pallet_multisig::Config for Runtime {
@@ -294,7 +294,7 @@ impl pallet_grandpa::Config for Runtime {
 // --- Torus ---
 
 const fn as_tors(val: u128) -> u128 {
-    val * 10u128.pow(TOKEN_DECIMALS)
+    val.saturating_mul(10u128.pow(TOKEN_DECIMALS))
 }
 
 parameter_types! {

--- a/runtime/src/configs/eth.rs
+++ b/runtime/src/configs/eth.rs
@@ -30,12 +30,10 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for FindAuthorTruncated<F> {
     where
         I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
     {
-        if let Some(author_index) = F::find_author(digests) {
-            let authority_id =
-                pallet_aura::Authorities::<Runtime>::get()[author_index as usize].clone();
-            return Some(H160::from_slice(&authority_id.to_raw_vec()[4..24]));
-        }
-        None
+        use pallet_aura::Authorities;
+        F::find_author(digests)
+            .and_then(|index| Authorities::<Runtime>::get().get(index as usize).cloned())
+            .and_then(|id| id.to_raw_vec().get(4..24).map(H160::from_slice))
     }
 }
 
@@ -58,7 +56,7 @@ pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(WEIGHT_REF_TIME_PER_
 
 parameter_types! {
     pub BlockGasLimit: U256
-        = U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
+        = U256::from((NORMAL_DISPATCH_RATIO.deconstruct() as u64).saturating_mul(MAXIMUM_BLOCK_WEIGHT.ref_time()).checked_div(WEIGHT_PER_GAS).unwrap_or(0));
     pub const GasLimitPovSizeRatio: u64 = 16;
     /// The amount of gas per storage (in bytes): BLOCK_GAS_LIMIT / BLOCK_STORAGE_LIMIT
     /// The current definition of BLOCK_STORAGE_LIMIT is 160 KB, resulting in a value of 366.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -39,7 +39,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("torus-runtime"),
     impl_name: create_runtime_str!("torus-runtime"),
     authoring_version: 1,
-    spec_version: 11,
+    spec_version: 12,
     impl_version: 1,
     apis: apis::RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -83,13 +83,7 @@ pub type SignedPayload = sp_runtime::generic::SignedPayload<RuntimeCall, SignedE
 /// All migrations of the runtime, aside from the ones declared in the pallets.
 ///
 /// This can be a tuple of types, each implementing `OnRuntimeUpgrade`.
-type Migrations = (
-    pallet_governance::migrations::v1::Migration<Runtime, RocksDbWeight>,
-    pallet_governance::migrations::v2::Migration<Runtime, RocksDbWeight>,
-    pallet_emission0::migrations::v1::Migration<Runtime, RocksDbWeight>,
-    pallet_torus0::migrations::v1::Migration<Runtime, RocksDbWeight>,
-    pallet_torus0::migrations::v2::Migration<Runtime, RocksDbWeight>,
-);
+type Migrations = (pallet_torus0::migrations::v3::Migration<Runtime, RocksDbWeight>,);
 
 /// Executive: handles dispatch to the various modules.
 pub type RuntimeExecutive = frame_executive::Executive<

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, unexpected_cfgs)]
 
 use std::{cell::RefCell, num::NonZeroU128};
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -124,7 +124,7 @@ struct Account<'a> {
     pub(crate) grandpa_address: sp_keyring::Ed25519Keyring,
 }
 
-impl<'a> Default for Account<'a> {
+impl Default for Account<'_> {
     fn default() -> Self {
         Self {
             suri: "".into(),


### PR DESCRIPTION
This patch fixes the de-registration code to clear the map after the stake has been refunded to the accounts. A previous test case ensure the _wrong_ behavior, which is now fixed.

An agent this week deregistered and got its tokens locked because of order of operations. Luckly, because the TotalStake storage is still wrong, the imbalance represents the amount needed to be refunded without minting new tokens.

Closes CHAIN-103.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue in staking logic to ensure proper refunding of stake during agent unregistration and runtime upgrades.
  - Updated migration logic to correct stake imbalances from previous versions.

- **Refactor**
  - Improved clarity and maintainability of stake removal logic.
  - Enhanced parameter naming for better readability.
  - Modified operation order in agent unregistration for consistency.

- **Tests**
  - Revised and renamed tests to better reflect updated agent unregistration and staking behaviors.

- **Chores**
  - Updated runtime and storage version numbers to reflect the latest changes.
  - Introduced workspace-wide linting configurations for consistent code quality.
  - Enforced stricter Clippy lint rules across the workspace.
  - Applied saturating arithmetic in various runtime and pallet modules to prevent overflow issues.
  - Improved arithmetic safety and robustness in emission and governance modules.
  - Refined author identification and gas limit calculations with safer arithmetic operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->