### PR TITLE
refac(torus0): stake in reserved balance

### DIFF
--- a/pallets/emission0/src/distribute.rs
+++ b/pallets/emission0/src/distribute.rs
@@ -374,8 +374,11 @@ fn linear_rewards<T: Config>(mut emission: NegativeImbalanceOf<T>) -> NegativeIm
             );
 
             let raw_amount = amount.peek();
+
             T::Currency::resolve_creating(&staker, amount);
-            let _ = <T::Torus>::stake_to(&staker, &input.agent_id, raw_amount);
+            if let Err(err) = <T::Torus>::stake_to(&staker, &input.agent_id, raw_amount) {
+                error!("failed to stake {raw_amount} tokens to {staker:?}: {err:?}");
+            }
         };
 
         if dividend.peek() != 0 {

--- a/pallets/emission0/src/migrations.rs
+++ b/pallets/emission0/src/migrations.rs
@@ -5,7 +5,7 @@ use polkadot_sdk::frame_support::{
 use crate::{Config, Pallet};
 
 pub mod v2 {
-    use polkadot_sdk::sp_std::collections::btree_set::BTreeSet;
+    use polkadot_sdk::{sp_std::collections::btree_set::BTreeSet, sp_tracing::error};
 
     use pallet_emission0_api::Emission0Api;
     use pallet_governance_api::GovernanceApi;
@@ -30,13 +30,13 @@ pub mod v2 {
                             &agent, allocator,
                         )
                     {
-                        polkadot_sdk::sp_tracing::error!(
+                        error!(
                             "failed to delegate weight control from {agent:?} to {allocator:?}: {err:?}"
                         );
                     }
                 }
             } else {
-                polkadot_sdk::sp_tracing::error!("no allocators available");
+                error!("no allocators available");
             }
 
             Weight::zero()

--- a/pallets/emission0/tests/distribution.rs
+++ b/pallets/emission0/tests/distribution.rs
@@ -8,6 +8,7 @@ use pallet_emission0::{
     PendingEmission, WeightControlDelegation,
 };
 use polkadot_sdk::{
+    frame_support::traits::Currency,
     pallet_balances,
     sp_core::Get,
     sp_runtime::{BoundedVec, FixedU128, Perbill, Percent},
@@ -19,7 +20,7 @@ use test_utils::{
         stake::sum_staked_by, Agents, FeeConstraints, MaxAllowedValidators, MinAllowedStake,
         MinValidatorStake, StakedBy,
     },
-    register_empty_agent, step_block, Test,
+    register_empty_agent, step_block, AccountId, Balances, ExistentialDeposit, Test,
 };
 
 #[test]
@@ -396,6 +397,9 @@ fn pays_dividends_to_stakers() {
         ConsensusMembers::<Test>::set(miner, Some(Default::default()));
 
         for id in [validator, miner] {
+            let _ =
+                <Balances as Currency<AccountId>>::deposit_creating(&id, ExistentialDeposit::get());
+
             register_empty_agent(id);
         }
 
@@ -594,6 +598,9 @@ fn pays_weight_delegation_fee_to_validators_without_permits() {
         ConsensusMembers::<Test>::set(miner, Some(Default::default()));
 
         for id in [val_1, val_2, miner] {
+            let _ =
+                <Balances as Currency<AccountId>>::deposit_creating(&id, ExistentialDeposit::get());
+
             register_empty_agent(id);
         }
 

--- a/pallets/faucet/tests/faucet.rs
+++ b/pallets/faucet/tests/faucet.rs
@@ -148,6 +148,7 @@ impl pallet_torus0::Config for Test {
     type RuntimeEvent = RuntimeEvent;
 
     type Currency = Balances;
+    type ExistentialDeposit = ExistentialDeposit;
 
     type Governance = Governance;
 
@@ -273,7 +274,7 @@ impl pallet_balances::Config for Test {
     type MaxLocks = MaxLocks;
     type WeightInfo = ();
     type MaxReserves = MaxReserves;
-    type ReserveIdentifier = ();
+    type ReserveIdentifier = [u8; 8];
     type RuntimeHoldReason = ();
     type FreezeIdentifier = ();
     type MaxFreezes = polkadot_sdk::frame_support::traits::ConstU32<16>;

--- a/pallets/torus0/api/src/lib.rs
+++ b/pallets/torus0/api/src/lib.rs
@@ -10,6 +10,7 @@ use core::{
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use polkadot_sdk::{
+    frame_support::dispatch::DispatchResult,
     sp_core::ConstU32,
     sp_runtime::{BoundedVec, Percent},
     sp_std::vec::Vec,
@@ -33,7 +34,7 @@ pub trait Torus0Api<AccountId, Balance> {
     fn sum_staking_to(staker: &AccountId) -> Balance;
 
     fn staked_by(staked: &AccountId) -> alloc::vec::Vec<(AccountId, Balance)>;
-    fn stake_to(staker: &AccountId, staked: &AccountId, amount: Balance) -> Result<(), Balance>;
+    fn stake_to(staker: &AccountId, staked: &AccountId, amount: Balance) -> DispatchResult;
 
     fn agent_ids() -> impl Iterator<Item = AccountId>;
     fn is_agent_registered(agent: &AccountId) -> bool;
@@ -47,7 +48,7 @@ pub trait Torus0Api<AccountId, Balance> {
         name: alloc::vec::Vec<u8>,
         url: alloc::vec::Vec<u8>,
         metadata: alloc::vec::Vec<u8>,
-    ) -> polkadot_sdk::frame_support::dispatch::DispatchResult;
+    ) -> DispatchResult;
 
     #[doc(hidden)]
     #[cfg(feature = "runtime-benchmarks")]

--- a/pallets/torus0/src/lib.rs
+++ b/pallets/torus0/src/lib.rs
@@ -34,14 +34,14 @@ use crate::{agent::Agent, burn::BurnConfiguration, fee::ValidatorFeeConstraints}
 
 #[frame::pallet]
 pub mod pallet {
-    const STORAGE_VERSION: StorageVersion = StorageVersion::new(5);
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(6);
 
     use frame::prelude::BlockNumberFor;
     use pallet_emission0_api::Emission0Api;
     use pallet_governance_api::GovernanceApi;
     use pallet_permission0_api::Permission0NamespacesApi;
     use pallet_torus0_api::NamespacePathInner;
-    use polkadot_sdk::frame_support::traits::ReservableCurrency;
+    use polkadot_sdk::frame_support::traits::{NamedReservableCurrency, ReservableCurrency};
     use weights::WeightInfo;
 
     use super::*;
@@ -257,8 +257,10 @@ pub mod pallet {
 
         type Currency: Currency<Self::AccountId, Balance = u128>
             + ReservableCurrency<Self::AccountId>
+            + NamedReservableCurrency<Self::AccountId, ReserveIdentifier = [u8; 8]>
             + Send
             + Sync;
+        type ExistentialDeposit: Get<BalanceOf<Self>>;
 
         type Governance: GovernanceApi<Self::AccountId>;
 
@@ -577,8 +579,8 @@ impl<T: Config>
         staker: &T::AccountId,
         staked: &T::AccountId,
         amount: <T::Currency as Currency<T::AccountId>>::Balance,
-    ) -> Result<(), <T::Currency as Currency<T::AccountId>>::Balance> {
-        stake::add_stake::<T>(staker.clone(), staked.clone(), amount).map_err(|_| amount)
+    ) -> DispatchResult {
+        stake::add_stake::<T>(staker.clone(), staked.clone(), amount)
     }
 
     fn agent_ids() -> impl Iterator<Item = T::AccountId> {

--- a/pallets/torus0/src/migrations.rs
+++ b/pallets/torus0/src/migrations.rs
@@ -177,7 +177,7 @@ pub mod v6 {
         },
         sp_core::Get,
         sp_std::collections::btree_set::BTreeSet,
-        sp_tracing::{error, info},
+        sp_tracing::{error, info, warn},
         sp_weights::Weight,
     };
 
@@ -188,42 +188,92 @@ pub mod v6 {
 
     impl<T: Config> UncheckedOnRuntimeUpgrade for MigrateToV6<T> {
         fn on_runtime_upgrade() -> Weight {
+            let ed = T::ExistentialDeposit::get();
             let mut minted = 0u128;
-            for (staker, _, amount) in crate::StakingTo::<T>::iter() {
-                let to_mint = if T::Currency::free_balance(&staker) == 0 {
-                    amount.saturating_add(T::ExistentialDeposit::get())
+
+            let total_stake_before = crate::TotalStake::<T>::get();
+            let total_issuance_before = T::Currency::total_issuance();
+            let total_tokens_before = total_stake_before.saturating_add(total_issuance_before);
+
+            for (staker, staked, original_stake) in crate::StakingTo::<T>::iter() {
+                let free = T::Currency::free_balance(&staker);
+
+                let mint = original_stake;
+                let stake = if free < ed {
+                    original_stake.checked_sub(ed).unwrap_or_default()
                 } else {
-                    amount
+                    original_stake
                 };
 
-                let imbalance = T::Currency::deposit_creating(&staker, to_mint);
-                if imbalance.peek() != to_mint {
+                let imbalance = T::Currency::deposit_creating(&staker, mint);
+                if imbalance.peek() != mint {
                     error!(
-                        "failed to mint {to_mint} stake tokens for account {staker:?}: actual {}",
+                        "failed to mint {mint} stake tokens for account {staker:?}: actual {}",
                         imbalance.peek()
                     );
                     continue;
                 }
-                if let Err(err) = T::Currency::reserve_named(STAKE_IDENTIFIER, &staker, amount) {
-                    error!("failed to reserve minted {amount} stake tokens for account {staker:?}: {err:?}");
+
+                if stake > 0 {
+                    if let Err(err) = T::Currency::reserve_named(STAKE_IDENTIFIER, &staker, stake) {
+                        error!(
+                            "failed to reserve {stake} stake tokens for account {staker:?}: {err:?}"
+                        );
+                    }
                 }
-                minted = minted.saturating_add(amount);
+
+                if original_stake != stake {
+                    let diff = mint.saturating_sub(stake);
+                    warn!(
+                        "updating total stake for a difference of {diff} tokens for stake {staker:?} -> {staked:?}",
+                    );
+
+                    crate::TotalStake::<T>::mutate(|total| {
+                        *total = total.saturating_sub(diff);
+                    });
+                    crate::StakingTo::<T>::mutate(&staker, &staked, |total| {
+                        if let Some(total) = total {
+                            *total = stake;
+                        }
+                    });
+                    crate::StakedBy::<T>::mutate(&staked, &staker, |total| {
+                        if let Some(total) = total {
+                            *total = stake;
+                        }
+                    });
+                }
+
+                minted = minted.saturating_add(mint);
             }
 
-            info!("total stake minted: {minted}");
-
+            let total_staking_to: u128 = crate::StakingTo::<T>::iter_values().sum();
+            let total_staked_by: u128 = crate::StakedBy::<T>::iter_values().sum();
             let total_reserved: u128 = crate::StakingTo::<T>::iter_keys()
                 .map(|(staker, _)| staker)
                 .collect::<BTreeSet<_>>()
                 .into_iter()
                 .map(|staker| T::Currency::reserved_balance_named(STAKE_IDENTIFIER, &staker))
                 .sum();
-            let total_staked = crate::TotalStake::<T>::get();
 
-            if total_reserved != total_staked {
-                error!("total reserved balance does not match total tracked state: {total_reserved} != {total_staked}");
-            } else {
-                info!("all stake was minted and reserved correctly");
+            let total_stake_after = crate::TotalStake::<T>::get();
+            let total_issuance_after = T::Currency::total_issuance();
+
+            info!("total stake minted: {minted}. total issuance: {total_issuance_after}. total issuance before: {total_issuance_before}");
+
+            if total_issuance_after != total_tokens_before {
+                error!("total issuance does not match total tokens before migration");
+            }
+
+            if total_staking_to != total_staked_by {
+                error!("total staking to does not match total staked by");
+            }
+
+            if total_staking_to != total_stake_after {
+                error!("total staking to does not match total staked after");
+            }
+
+            if total_reserved != total_stake_after {
+                error!("total reserved balance does not match total tracked state: {total_reserved} != {total_stake_after}");
             }
 
             Weight::default()

--- a/pallets/torus0/tests/stake.rs
+++ b/pallets/torus0/tests/stake.rs
@@ -67,19 +67,14 @@ fn transfer_stake_correctly() {
         ));
 
         assert_ok!(pallet_torus0::agent::register::<Test>(
-        <<<<<<< HEAD
-                    to,
-        =======
-                    old_staked,
-                    old_staked,
-        >>>>>>> 77dd61d (refac(torus0): stake in reserved balance)
-                    "to".as_bytes().to_vec(),
-                    "to://idk".as_bytes().to_vec(),
-                    "idk".as_bytes().to_vec()
-                ));
+            old_staked,
+            "to".as_bytes().to_vec(),
+            "to://idk".as_bytes().to_vec(),
+            "idk".as_bytes().to_vec()
+        ));
 
         assert_ok!(pallet_torus0::agent::register::<Test>(
-            transfer,
+            new_staked,
             "transfer".as_bytes().to_vec(),
             "transfer://idk".as_bytes().to_vec(),
             "idk".as_bytes().to_vec()

--- a/pallets/torus0/tests/stake.rs
+++ b/pallets/torus0/tests/stake.rs
@@ -1,5 +1,10 @@
-use pallet_torus0::{Error, MinAllowedStake, StakedBy, StakingTo, TotalStake};
-use polkadot_sdk::frame_support::{assert_err, traits::Currency};
+use pallet_torus0::{
+    stake::STAKE_IDENTIFIER, Error, MinAllowedStake, StakedBy, StakingTo, TotalStake,
+};
+use polkadot_sdk::frame_support::{
+    assert_err,
+    traits::{Currency, NamedReservableCurrency},
+};
 use test_utils::{as_tors, assert_ok, get_origin, pallet_governance, Balances, Test};
 
 #[test]
@@ -31,7 +36,13 @@ fn add_stake_correctly() {
             stake_to_add
         ));
 
-        assert_eq!(Balances::total_balance(&from), balance_after);
+        assert_eq!(Balances::total_balance(&from), total_balance);
+        assert_eq!(Balances::free_balance(from), balance_after);
+        assert_eq!(
+            Balances::reserved_balance_named(STAKE_IDENTIFIER, &from),
+            balance_after
+        );
+
         assert_eq!(StakingTo::<Test>::get(from, to), Some(stake_to_add));
         assert_eq!(StakedBy::<Test>::get(to, from), Some(stake_to_add));
         assert_eq!(TotalStake::<Test>::get(), stake_to_add);
@@ -41,24 +52,31 @@ fn add_stake_correctly() {
 #[test]
 fn transfer_stake_correctly() {
     test_utils::new_test_ext().execute_with(|| {
-        let from = 0;
-        let to = 1;
-        let transfer = 2;
+        let staker = 0;
+        let old_staked = 1;
+        let new_staked = 2;
         let stake_to_add = MinAllowedStake::<Test>::get();
         let total_balance = stake_to_add * 2;
         let balance_after = stake_to_add;
 
-        assert_ok!(pallet_governance::whitelist::add_to_whitelist::<Test>(to));
         assert_ok!(pallet_governance::whitelist::add_to_whitelist::<Test>(
-            transfer
+            old_staked
+        ));
+        assert_ok!(pallet_governance::whitelist::add_to_whitelist::<Test>(
+            new_staked
         ));
 
         assert_ok!(pallet_torus0::agent::register::<Test>(
-            to,
-            "to".as_bytes().to_vec(),
-            "to://idk".as_bytes().to_vec(),
-            "idk".as_bytes().to_vec()
-        ));
+        <<<<<<< HEAD
+                    to,
+        =======
+                    old_staked,
+                    old_staked,
+        >>>>>>> 77dd61d (refac(torus0): stake in reserved balance)
+                    "to".as_bytes().to_vec(),
+                    "to://idk".as_bytes().to_vec(),
+                    "idk".as_bytes().to_vec()
+                ));
 
         assert_ok!(pallet_torus0::agent::register::<Test>(
             transfer,
@@ -67,33 +85,60 @@ fn transfer_stake_correctly() {
             "idk".as_bytes().to_vec()
         ));
 
-        let _ = Balances::deposit_creating(&from, total_balance);
+        let _ = Balances::deposit_creating(&staker, total_balance);
 
-        assert_eq!(Balances::total_balance(&from), total_balance);
-        assert_eq!(Balances::total_balance(&to), 0);
+        assert_eq!(Balances::total_balance(&staker), total_balance);
+        assert_eq!(Balances::total_balance(&old_staked), 0);
 
         assert_ok!(pallet_torus0::Pallet::<Test>::add_stake(
-            get_origin(from),
-            to,
+            get_origin(staker),
+            old_staked,
             stake_to_add
         ));
 
-        assert_eq!(Balances::total_balance(&from), balance_after);
-        assert_eq!(StakingTo::<Test>::get(from, to), Some(stake_to_add));
-        assert_eq!(StakedBy::<Test>::get(to, from), Some(stake_to_add));
+        assert_eq!(Balances::total_balance(&staker), total_balance);
+        assert_eq!(Balances::free_balance(staker), balance_after);
+        assert_eq!(
+            Balances::reserved_balance_named(STAKE_IDENTIFIER, &staker),
+            stake_to_add
+        );
+
+        assert_eq!(
+            StakingTo::<Test>::get(staker, old_staked),
+            Some(stake_to_add)
+        );
+        assert_eq!(
+            StakedBy::<Test>::get(old_staked, staker),
+            Some(stake_to_add)
+        );
         assert_eq!(TotalStake::<Test>::get(), stake_to_add);
 
         assert_ok!(pallet_torus0::Pallet::<Test>::transfer_stake(
-            get_origin(from),
-            to,
-            transfer,
+            get_origin(staker),
+            old_staked,
+            new_staked,
             stake_to_add
         ));
 
-        assert_eq!(StakingTo::<Test>::get(from, to), Some(0));
-        assert_eq!(StakingTo::<Test>::get(from, transfer), Some(stake_to_add));
-        assert_eq!(StakedBy::<Test>::get(to, from), Some(0));
-        assert_eq!(StakedBy::<Test>::get(transfer, from), Some(stake_to_add));
+        assert_eq!(Balances::total_balance(&staker), total_balance);
+        assert_eq!(Balances::free_balance(staker), balance_after);
+        assert_eq!(
+            Balances::reserved_balance_named(STAKE_IDENTIFIER, &staker),
+            stake_to_add
+        );
+
+        assert_eq!(StakingTo::<Test>::get(staker, old_staked), Some(0));
+        assert_eq!(StakedBy::<Test>::get(old_staked, staker), Some(0));
+
+        assert_eq!(
+            StakingTo::<Test>::get(staker, new_staked),
+            Some(stake_to_add)
+        );
+        assert_eq!(
+            StakedBy::<Test>::get(new_staked, staker),
+            Some(stake_to_add)
+        );
+
         assert_eq!(TotalStake::<Test>::get(), stake_to_add);
     });
 }
@@ -174,6 +219,12 @@ fn remove_stake_correctly() {
             stake_to_add_and_remove
         ));
 
+        assert_eq!(Balances::total_balance(&from), total_balance);
+        assert_eq!(
+            Balances::free_balance(from),
+            total_balance - stake_to_add_and_remove
+        );
+
         assert_ok!(pallet_torus0::Pallet::<Test>::remove_stake(
             get_origin(from),
             to,
@@ -181,6 +232,8 @@ fn remove_stake_correctly() {
         ));
 
         assert_eq!(Balances::total_balance(&from), total_balance);
+        assert_eq!(Balances::free_balance(from), total_balance);
+
         assert_eq!(StakingTo::<Test>::get(from, to), Some(0));
         assert_eq!(StakedBy::<Test>::get(to, from), Some(0));
         assert_eq!(TotalStake::<Test>::get(), 0);
@@ -214,7 +267,8 @@ fn remove_stake_with_deregistered_agent() {
             stake,
         ));
 
-        assert_eq!(Balances::total_balance(&from), total_balance / 2);
+        assert_eq!(Balances::total_balance(&from), total_balance);
+        assert_eq!(Balances::free_balance(from), total_balance / 2);
 
         assert_eq!(TotalStake::<Test>::get(), stake);
         assert_eq!(StakingTo::<Test>::get(from, to), Some(stake));
@@ -230,6 +284,8 @@ fn remove_stake_with_deregistered_agent() {
         );
 
         assert_eq!(Balances::total_balance(&from), total_balance);
+        assert_eq!(Balances::free_balance(from), total_balance);
+
         assert_eq!(StakingTo::<Test>::get(from, to), None);
         assert_eq!(StakedBy::<Test>::get(to, from), None);
         assert_eq!(TotalStake::<Test>::get(), 0);

--- a/runtime/src/configs.rs
+++ b/runtime/src/configs.rs
@@ -105,7 +105,7 @@ impl pallet_balances::Config for Runtime {
     /// 0.1 Unit
     type ExistentialDeposit = ConstU128<EXISTENTIAL_DEPOSIT>;
     /// The identifier for reserved tokens
-    type ReserveIdentifier = ();
+    type ReserveIdentifier = [u8; 8];
     /// The identifier for frozen tokens
     type FreezeIdentifier = Self::RuntimeFreezeReason;
     /// Handler for the unspent dust that gets burned
@@ -366,6 +366,7 @@ impl pallet_torus0::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
 
     type Currency = Balances;
+    type ExistentialDeposit = ConstU128<EXISTENTIAL_DEPOSIT>;
 
     type Governance = Governance;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -89,6 +89,7 @@ type Migrations = (
     pallet_permission0::migrations::v4::Migration<Runtime, RocksDbWeight>,
     pallet_torus0::migrations::v4::Migration<Runtime, RocksDbWeight>,
     pallet_torus0::migrations::v5::Migration<Runtime, RocksDbWeight>,
+    pallet_torus0::migrations::v6::Migration<Runtime, RocksDbWeight>,
 );
 
 /// Executive: handles dispatch to the various modules.

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -154,6 +154,7 @@ impl pallet_torus0::Config for Test {
     type RuntimeEvent = RuntimeEvent;
 
     type Currency = Balances;
+    type ExistentialDeposit = ExistentialDeposit;
 
     type Governance = Governance;
 
@@ -278,7 +279,7 @@ impl pallet_balances::Config for Test {
     type MaxLocks = MaxLocks;
     type WeightInfo = ();
     type MaxReserves = MaxReserves;
-    type ReserveIdentifier = ();
+    type ReserveIdentifier = [u8; 8];
     type RuntimeHoldReason = ();
     type FreezeIdentifier = ();
     type MaxFreezes = polkadot_sdk::frame_support::traits::ConstU32<16>;


### PR DESCRIPTION
This change prevents errors that might happen when we wrongly track stake changes. By moving to reserved balances, we avoid minting tokens when unstaking from accounts.

Closes CHAIN-104.