### PR TITLE
fix(namespaces): prevent de-registering root

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748162331,
-        "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
+        "lastModified": 1751741127,
+        "narHash": "sha256-t75Shs76NgxjZSgvvZZ9qOmz5zuBE8buUaYD28BMTxg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
+        "rev": "29e290002bfff26af1db6f64d070698019460302",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747372754,
-        "narHash": "sha256-2Y53NGIX2vxfie1rOW0Qb86vjRZ7ngizoo+bnXU9D9k=",
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748313401,
-        "narHash": "sha256-x5UuDKP2Ui/TresAngUo9U4Ss9xfOmN8dAXU8OrkZmA=",
+        "lastModified": 1751769931,
+        "narHash": "sha256-QR2Rp/41NkA5YxcpvZEKD1S2QE1Pb9U415aK8M/4tJc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9c8ea175cf9af29edbcff121512e44092a8f37e4",
+        "rev": "3ac4f630e375177ea8317e22f5c804156de177e8",
         "type": "github"
       },
       "original": {

--- a/node/src/cli/eth.rs
+++ b/node/src/cli/eth.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::result_large_err)]
+
 use std::{
     collections::BTreeMap,
     path::PathBuf,

--- a/node/src/command/benchmarking.rs
+++ b/node/src/command/benchmarking.rs
@@ -171,6 +171,6 @@ pub fn inherent_benchmark_data() -> Result<InherentData> {
     let timestamp = sp_timestamp::InherentDataProvider::new(d.into());
 
     futures::executor::block_on(timestamp.provide_inherent_data(&mut inherent_data))
-        .map_err(|e| format!("creating inherent data: {:?}", e))?;
+        .map_err(|e| format!("creating inherent data: {e:?}"))?;
     Ok(inherent_data)
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 //! The Torus node implementation.
 
 mod chain_spec;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -14,6 +14,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![allow(clippy::result_large_err)]
 
 use std::{pin::Pin, sync::Arc, time::Duration};
 

--- a/pallets/emission0/src/distribute.rs
+++ b/pallets/emission0/src/distribute.rs
@@ -204,9 +204,11 @@ impl<T: Config> ConsensusMemberInput<T> {
 
         let validator_permit = total_stake >= min_validator_stake && !weights.is_empty();
 
-        let weights = validator_permit
-            .then(|| Self::prepare_weights(weights, &agent_id))
-            .unwrap_or_default();
+        let weights = if validator_permit {
+            Self::prepare_weights(weights, &agent_id)
+        } else {
+            Default::default()
+        };
 
         ConsensusMemberInput {
             registered: <T::Torus>::is_agent_registered(&agent_id)

--- a/pallets/torus0/src/agent.rs
+++ b/pallets/torus0/src/agent.rs
@@ -1,7 +1,7 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use pallet_emission0_api::Emission0Api;
 use pallet_governance_api::GovernanceApi;
-use pallet_torus0_api::{NamespacePath, NAMESPACE_AGENT_PREFIX};
+use pallet_torus0_api::NamespacePath;
 use polkadot_sdk::{
     frame_election_provider_support::Get,
     frame_support::{
@@ -78,8 +78,7 @@ pub fn register<T: crate::Config>(
         crate::Error::<T>::TooManyAgentRegistrationsThisInterval
     );
 
-    let namespace_path: Vec<_> = [NAMESPACE_AGENT_PREFIX, &name].concat();
-    let namespace_path = NamespacePath::new_agent(&namespace_path).map_err(|err| {
+    let namespace_path = NamespacePath::new_agent_root(&name).map_err(|err| {
         warn!("{agent_key:?} tried using invalid name: {err:?}");
         crate::Error::<T>::InvalidNamespacePath
     })?;
@@ -140,8 +139,7 @@ pub fn unregister<T: crate::Config>(agent_key: AccountIdOf<T>) -> DispatchResult
 
     let agent = crate::Agents::<T>::get(&agent_key).ok_or(crate::Error::<T>::AgentDoesNotExist)?;
 
-    let namespace_path: Vec<_> = [NAMESPACE_AGENT_PREFIX, &agent.name].concat();
-    let namespace_path = NamespacePath::new_agent(&namespace_path)
+    let namespace_path = NamespacePath::new_agent_root(&agent.name)
         .map_err(|_| crate::Error::<T>::InvalidNamespacePath)?;
     crate::namespace::delete_namespace::<T>(
         crate::namespace::NamespaceOwnership::Account(agent_key.clone()),

--- a/pallets/torus0/src/lib.rs
+++ b/pallets/torus0/src/lib.rs
@@ -390,8 +390,8 @@ pub mod pallet {
                 NamespacePath::new_agent(&path).map_err(|_| Error::<T>::InvalidNamespacePath)?;
 
             ensure!(
-                !T::Permission0::is_delegating_namespace(&owner, &namespace_path),
-                Error::<T>::NamespaceBeingDelegated
+                !namespace_path.is_agent_root(),
+                Error::<T>::InvalidNamespacePath
             );
 
             namespace::delete_namespace::<T>(NamespaceOwnership::Account(owner), namespace_path)

--- a/pallets/torus0/src/migrations.rs
+++ b/pallets/torus0/src/migrations.rs
@@ -64,7 +64,7 @@ pub mod v4 {
 }
 
 pub mod v5 {
-    use pallet_torus0_api::{NamespacePath, NAMESPACE_AGENT_PREFIX};
+    use pallet_torus0_api::NamespacePath;
     use polkadot_sdk::{
         frame_support::{migrations::VersionedMigration, traits::UncheckedOnRuntimeUpgrade},
         sp_tracing::{error, info},
@@ -138,15 +138,10 @@ pub mod v5 {
                     continue;
                 };
 
-                let path: polkadot_sdk::sp_std::vec::Vec<_> =
-                    [NAMESPACE_AGENT_PREFIX, agent_name.as_bytes()].concat();
-                let path = match NamespacePath::new_agent(&path) {
+                let path = match NamespacePath::new_agent_root(agent_name.as_bytes()) {
                     Ok(path) => path,
                     Err(err) => {
-                        error!(
-                            "cannot create path for agent {agent_name:?} ({:?}): {err:?}",
-                            core::str::from_utf8(&path)
-                        );
+                        error!("cannot create path for agent {agent_name:?}: {err:?}");
                         continue;
                     }
                 };

--- a/pallets/torus0/src/namespace.rs
+++ b/pallets/torus0/src/namespace.rs
@@ -1,5 +1,6 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use pallet_governance_api::GovernanceApi;
+use pallet_permission0_api::Permission0NamespacesApi;
 use polkadot_sdk::{
     frame_support::{
         traits::{ExistenceRequirement, ReservableCurrency},
@@ -261,6 +262,13 @@ pub fn delete_namespace<T: Config>(
         Namespaces::<T>::contains_key(&owner, &path),
         Error::<T>::NamespaceNotFound
     );
+
+    if let NamespaceOwnership::Account(owner) = &owner {
+        ensure!(
+            !T::Permission0::is_delegating_namespace(owner, &path),
+            Error::<T>::NamespaceBeingDelegated
+        );
+    }
 
     let mut total_deposit = BalanceOf::<T>::zero();
     let namespaces_to_delete: Vec<_> = Namespaces::<T>::iter_prefix(&owner)

--- a/pallets/torus0/tests/agent.rs
+++ b/pallets/torus0/tests/agent.rs
@@ -1,5 +1,6 @@
 use pallet_governance_api::GovernanceApi;
 use pallet_torus0::{agent::Agent, AgentUpdateCooldown, Agents, Burn, Error};
+use pallet_torus0_api::NamespacePath;
 use polkadot_sdk::{frame_support::assert_err, sp_core::Get, sp_runtime::Percent};
 use test_utils::{
     assert_ok, clear_cooldown, get_balance, get_origin,
@@ -18,7 +19,7 @@ fn register_correctly() {
         let agent_id = 0;
         let allocator_id = 1;
 
-        let name = b"agent".to_vec();
+        let name = b"alice".to_vec();
         let url = b"idk://agent".to_vec();
         let metadata = b"idk://agent".to_vec();
 
@@ -63,6 +64,11 @@ fn register_correctly() {
             WeightControlDelegation::<Test>::get(agent.key),
             Some(allocator_id)
         );
+
+        assert!(pallet_torus0::Namespaces::<Test>::contains_key(
+            pallet_torus0::namespace::NamespaceOwnership::Account(agent_id),
+            "agent.alice".parse::<NamespacePath>().unwrap()
+        ));
 
         assert_err!(
             pallet_torus0::agent::register::<Test>(
@@ -339,7 +345,7 @@ fn register_more_than_registrations_per_interval() {
 fn unregister_correctly() {
     test_utils::new_test_ext().execute_with(|| {
         let agent = 0;
-        let name = b"agent".to_vec();
+        let name = b"alice".to_vec();
         let url = b"idk://agent".to_vec();
         let metadata = b"idk://agent".to_vec();
 
@@ -355,9 +361,19 @@ fn unregister_correctly() {
             metadata.clone(),
         ));
 
+        assert!(pallet_torus0::Namespaces::<Test>::contains_key(
+            pallet_torus0::namespace::NamespaceOwnership::Account(agent),
+            "agent.alice".parse::<NamespacePath>().unwrap()
+        ));
+
         assert_ok!(pallet_torus0::Pallet::<Test>::unregister_agent(get_origin(
             agent
         )));
+
+        assert!(!pallet_torus0::Namespaces::<Test>::contains_key(
+            pallet_torus0::namespace::NamespaceOwnership::Account(agent),
+            "agent.alice".parse::<NamespacePath>().unwrap()
+        ));
 
         assert!(pallet_torus0::Agents::<Test>::get(agent).is_none());
     });

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.88.0"
 components = [
     "clippy",
     "rustfmt",

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -266,7 +266,7 @@ impl pallet_permission0::Config for Test {
 
     type MinAutoDistributionThreshold = MinAutoDistributionThreshold;
 
-    type MaxNamespacesPerPermission = ConstU32<0>;
+    type MaxNamespacesPerPermission = ConstU32<10>;
 }
 
 impl pallet_balances::Config for Test {


### PR DESCRIPTION
This patch prevents a registered agent from de-registering the agent entry (`agent.<name>`) through the `delete_namespace` extrinsic.