### PR TITLE
fix(governance): keep agent registered when de-whitelisting

### DIFF
--- a/pallets/emission0/src/distribute.rs
+++ b/pallets/emission0/src/distribute.rs
@@ -92,11 +92,11 @@ pub struct ConsensusMemberInput<T: Config> {
     pub total_stake: u128,
     pub normalized_stake: FixedU128,
     pub delegating_to: Option<T::AccountId>,
-    pub registered: bool,
+    pub whitelisted: bool,
 }
 
 impl<T: Config> ConsensusMemberInput<T> {
-    pub fn from_new_agent(agent_id: T::AccountId, registered: bool) -> Self {
+    pub fn from_new_agent(agent_id: T::AccountId, whitelisted: bool) -> Self {
         Self {
             agent_id,
             validator_permit: Default::default(),
@@ -105,7 +105,7 @@ impl<T: Config> ConsensusMemberInput<T> {
             total_stake: Default::default(),
             normalized_stake: Default::default(),
             delegating_to: Default::default(),
-            registered,
+            whitelisted,
         }
     }
 
@@ -113,39 +113,39 @@ impl<T: Config> ConsensusMemberInput<T> {
     pub fn all_members() -> BTreeMap<T::AccountId, ConsensusMemberInput<T>> {
         let min_validator_stake = <T::Torus>::min_validator_stake();
 
-        let mut registered_agents: BTreeSet<_> = <T::Torus>::agent_ids()
+        let mut whitelisted_agents: BTreeSet<_> = <T::Torus>::agent_ids()
             .filter(<T::Governance>::is_whitelisted)
             .collect();
         let mut consensus_members: BTreeMap<_, _> = crate::ConsensusMembers::<T>::iter().collect();
 
         let mut inputs: Vec<_> = crate::WeightControlDelegation::<T>::iter()
-            .map(|(delegator, delegatee)| {
-                let is_registered = registered_agents.remove(&delegator);
+            .map(|(delegator, recipient)| {
+                let is_whitelisted = whitelisted_agents.remove(&delegator);
                 consensus_members.remove(&delegator);
 
-                let mut input = if let Some(delegatee_input) = consensus_members.get(&delegatee) {
+                let mut input = if let Some(delegatee_input) = consensus_members.get(&recipient) {
                     Self::from_agent(
                         delegator.clone(),
                         delegatee_input.weights.clone(),
                         min_validator_stake,
                     )
                 } else {
-                    Self::from_new_agent(delegator.clone(), is_registered)
+                    Self::from_new_agent(delegator.clone(), is_whitelisted)
                 };
 
-                input.delegating_to = Some(delegatee);
+                input.delegating_to = Some(recipient);
 
                 (delegator, input)
             })
             .collect();
 
-        inputs.extend(registered_agents.into_iter().map(|agent_id| {
-            let input = consensus_members
-                .remove(&agent_id)
-                .map(|member| {
-                    Self::from_agent(agent_id.clone(), member.weights, min_validator_stake)
-                })
-                .unwrap_or_else(|| Self::from_new_agent(agent_id.clone(), true));
+        inputs.extend(whitelisted_agents.into_iter().map(|agent_id| {
+            let input = if let Some(member) = consensus_members.remove(&agent_id) {
+                Self::from_agent(agent_id.clone(), member.weights, min_validator_stake)
+            } else {
+                Self::from_new_agent(agent_id.clone(), true)
+            };
+
             (agent_id, input)
         }));
 
@@ -211,7 +211,7 @@ impl<T: Config> ConsensusMemberInput<T> {
         };
 
         ConsensusMemberInput {
-            registered: <T::Torus>::is_agent_registered(&agent_id)
+            whitelisted: <T::Torus>::is_agent_registered(&agent_id)
                 && <T::Governance>::is_whitelisted(&agent_id),
 
             agent_id,
@@ -236,7 +236,8 @@ impl<T: Config> ConsensusMemberInput<T> {
             .filter(|(id, _)| {
                 id != agent_id
                     && (crate::ConsensusMembers::<T>::contains_key(id)
-                        || <T::Torus>::is_agent_registered(id))
+                        || (<T::Torus>::is_agent_registered(id)
+                            && <T::Governance>::is_whitelisted(id)))
             })
             .map(|(id, weight)| {
                 let weight = FixedU128::from_u32(weight as u32);
@@ -398,7 +399,7 @@ fn linear_rewards<T: Config>(mut emission: NegativeImbalanceOf<T>) -> NegativeIm
             add_stake(input.agent_id.clone(), remaining_emission);
         }
 
-        if input.registered {
+        if input.whitelisted {
             crate::ConsensusMembers::<T>::mutate(
                 &input.agent_id,
                 |member: &mut Option<ConsensusMember<T>>| {

--- a/pallets/emission0/tests/distribution.rs
+++ b/pallets/emission0/tests/distribution.rs
@@ -126,14 +126,14 @@ fn creates_member_input_correctly() {
                 total_stake: 0,
                 normalized_stake: FixedU128::from_inner(0),
                 delegating_to: None,
-                registered: false
+                whitelisted: false
             }
         );
 
         register_empty_agent(0);
 
         let input = ConsensusMemberInput::<Test>::from_agent(0, member.weights.clone(), 0);
-        assert!(input.registered);
+        assert!(input.whitelisted);
 
         StakedBy::<Test>::set(0, 1, Some(10));
         StakedBy::<Test>::set(0, 2, Some(20));
@@ -198,7 +198,7 @@ fn creates_list_of_all_member_inputs_for_rewards() {
                 total_stake: stake * 3,
                 normalized_stake: FixedU128::from_float(0.75f64),
                 delegating_to: None,
-                registered: true,
+                whitelisted: true,
             }
         );
 
@@ -212,7 +212,7 @@ fn creates_list_of_all_member_inputs_for_rewards() {
                 total_stake: 0,
                 normalized_stake: FixedU128::from_inner(0),
                 delegating_to: None,
-                registered: true,
+                whitelisted: true,
             }
         );
 
@@ -226,7 +226,7 @@ fn creates_list_of_all_member_inputs_for_rewards() {
                 total_stake: stake,
                 normalized_stake: FixedU128::from_float(0.25f64),
                 delegating_to: Some(validator),
-                registered: true,
+                whitelisted: true,
             }
         );
 
@@ -240,7 +240,7 @@ fn creates_list_of_all_member_inputs_for_rewards() {
                 total_stake: 0,
                 normalized_stake: FixedU128::from_inner(0),
                 delegating_to: Some(validator),
-                registered: false,
+                whitelisted: false,
             }
         );
 
@@ -254,7 +254,7 @@ fn creates_list_of_all_member_inputs_for_rewards() {
                 total_stake: 0,
                 normalized_stake: FixedU128::from_inner(0),
                 delegating_to: Some(validator),
-                registered: false,
+                whitelisted: false,
             }
         );
 
@@ -268,7 +268,7 @@ fn creates_list_of_all_member_inputs_for_rewards() {
                 total_stake: 0,
                 normalized_stake: FixedU128::from_inner(0),
                 delegating_to: None,
-                registered: true,
+                whitelisted: true,
             }
         );
     });

--- a/pallets/governance/src/whitelist.rs
+++ b/pallets/governance/src/whitelist.rs
@@ -14,6 +14,7 @@ pub fn add_to_whitelist<T: crate::Config>(key: AccountIdOf<T>) -> DispatchResult
 
     crate::Whitelist::<T>::insert(key.clone(), ());
     crate::Pallet::<T>::deposit_event(crate::Event::<T>::WhitelistAdded(key));
+
     Ok(())
 }
 
@@ -29,8 +30,8 @@ pub fn remove_from_whitelist<T: crate::Config>(key: AccountIdOf<T>) -> DispatchR
     }
 
     crate::Whitelist::<T>::remove(&key);
-    let _ = pallet_torus0::agent::deregister::<T>(key.clone());
     crate::Pallet::<T>::deposit_event(crate::Event::<T>::WhitelistRemoved(key));
+
     Ok(())
 }
 


### PR DESCRIPTION
Because an agent can now exist without being whitelisted, it doesn't make sense to de-register it when removed from the whitelist. Closes CHAIN-118.