### PR TITLE
feat(permission0): emit events on accumulation and distribution

### DIFF
--- a/pallets/permission0/src/lib.rs
+++ b/pallets/permission0/src/lib.rs
@@ -179,22 +179,6 @@ pub mod pallet {
             revoked_by: Option<T::AccountId>,
             permission_id: PermissionId,
         },
-        /// Permission executed (manual distribution) with ID
-        PermissionExecuted {
-            delegator: T::AccountId,
-            recipient: T::AccountId,
-            permission_id: PermissionId,
-            stream_id: Option<StreamId>,
-            amount: BalanceOf<T>,
-        },
-        /// Auto-distribution executed
-        AutoDistributionExecuted {
-            delegator: T::AccountId,
-            recipient: T::AccountId,
-            permission_id: PermissionId,
-            stream_id: Option<StreamId>,
-            amount: BalanceOf<T>,
-        },
         /// Permission expired with ID
         PermissionExpired {
             delegator: T::AccountId,
@@ -223,6 +207,20 @@ pub mod pallet {
             permission_id: PermissionId,
             controllers_count: u32,
             required_votes: u32,
+        },
+        /// An emission distribution happened
+        EmissionDistribution {
+            permission_id: PermissionId,
+            stream_id: Option<StreamId>,
+            target: T::AccountId,
+            amount: BalanceOf<T>,
+            reason: permission::emission::DistributionReason,
+        },
+        /// Accumulated emission for stream
+        AccumulatedEmission {
+            permission_id: PermissionId,
+            stream_id: StreamId,
+            amount: BalanceOf<T>,
         },
     }
 


### PR DESCRIPTION
Emit events on emission accumulation and distribution. This helps tracking where streams are flowing to. This change replaces `PermissionExecuted` and `AutoDistributionExecuted` for `EmissionDistribution` with a `reason` field and a new `AccumulatedEmission`.