### PR TITLE
refac(permission0): move recipient field to within the scope

### DIFF
--- a/docs/changes/spec-24.md
+++ b/docs/changes/spec-24.md
@@ -1,0 +1,182 @@
+# Runtime Spec Version 24 Changes
+
+This document outlines all interface changes between runtime spec version 23 and 24, including new extrinsics, modified events, storage changes, and behavioral updates.
+
+## Extrinsics
+
+### `permission0::update_namespace_permission` (NEW)
+
+```diff
++#[pallet::call_index(9)]
++pub fn update_namespace_permission(
++    origin: OriginFor<T>,
++    permission_id: PermissionId,
++    max_instances: u32,
++) -> DispatchResult
+```
+
+A new extrinsic that allows permission delegators to update the maximum number of instances allowed for a namespace permission. This provides delegators with the ability to dynamically adjust permission limits after initial creation, enabling more flexible permission management.
+
+### `permission0::delegate_emission_permission`
+
+```diff
+ pub fn delegate_emission_permission(
+     delegator: T::AccountId,
+-    recipient: T::AccountId,
++    recipients: Vec<(T::AccountId, u16)>,
+     allocation: EmissionAllocation<Balance>,
+-    targets: Vec<(T::AccountId, u16)>,
+     distribution: DistributionControl<Balance, BlockNumber>,
+     duration: PermissionDuration<BlockNumber>,
+     revocation: RevocationTerms<AccountId, BlockNumber>,
+     enforcement: EnforcementAuthority<AccountId>,
++    recipient_manager: Option<AccountId>,
++    weight_setter: Option<AccountId>,
+ ) -> Result<PermissionId, DispatchError>
+```
+
+The emission permission delegation has been restructured to consolidate recipients and their weights into a single parameter, while adding new optional manager fields. The `recipient_manager` can modify the list of recipients, while the `weight_setter` can adjust distribution weights, enabling more granular permission management.
+
+## Events
+
+### `permission0::PermissionDelegated`
+
+```diff
+ PermissionDelegated {
+     delegator: T::AccountId,
+-    recipient: T::AccountId,
+     permission_id: PermissionId,
+ }
+```
+
+The `recipient` field has been removed from the `PermissionDelegated` event since permissions can now have multiple recipients. Client applications should query the permission contract directly to determine recipients.
+
+### `permission0::PermissionRevoked`
+
+```diff
+ PermissionRevoked {
+     delegator: T::AccountId,
+-    recipient: T::AccountId,
+-    revoked_by: T::AccountId,
++    revoked_by: Option<T::AccountId>,
+     permission_id: PermissionId,
+ }
+```
+
+The `recipient` field has been removed and `revoked_by` is now optional to handle cases where permissions are revoked by the system automatically (e.g., expiration) rather than by a specific account.
+
+### `permission0::PermissionExpired`
+
+```diff
+ PermissionExpired {
+     delegator: T::AccountId,
+-    recipient: T::AccountId,
+     permission_id: PermissionId,
+ }
+```
+
+Consistent with other events, the `recipient` field has been removed from `PermissionExpired` events.
+
+## Storage Items
+
+No storage item names were changed in this version, but several storage values were migrated through the permission pallet's v6 migration to update the internal structure of permission contracts.
+
+## Structs & Enums
+
+### `permission0::PermissionContract<T>`
+
+```diff
+ pub struct PermissionContract<T: Config> {
+     pub delegator: T::AccountId,
+-    pub recipient: T::AccountId,
+     pub scope: PermissionScope<T>,
+     // ... other fields
+ }
+```
+
+The `recipient` field has been removed from the main contract structure since recipients are now scope-specific and can be multiple accounts for emission permissions.
+
+### `permission0::EmissionScope<T>`
+
+```diff
+ pub struct EmissionScope<T: Config> {
++    pub recipients: BoundedBTreeMap<T::AccountId, u16, T::MaxTargetsPerPermission>,
+     pub allocation: EmissionAllocation<T>,
+     pub distribution: DistributionControl<T>,
+-    pub targets: BoundedBTreeMap<T::AccountId, u16, T::MaxTargetsPerPermission>,
+     pub accumulating: bool,
++    pub recipient_manager: Option<T::AccountId>,
++    pub weight_setter: Option<T::AccountId>,
+ }
+```
+
+The `targets` field has been renamed to `recipients` for clarity, and new manager fields enable delegated management of recipients and weights within emission permissions.
+
+### `permission0::CuratorScope<T>`
+
+```diff
+ pub struct CuratorScope<T: Config> {
++    pub recipient: T::AccountId,
+     pub flags: BoundedBTreeMap<
+         Option<PermissionId>,
+         CuratorPermissions,
+         T::MaxCuratorSubpermissionsPerPermission,
+     >,
+     pub cooldown: Option<BlockNumberFor<T>>,
+ }
+```
+
+The `recipient` field has been added to track the specific recipient of curator permissions, and the flags structure now supports parent-child relationships through the optional PermissionId key.
+
+### `permission0::NamespaceScope<T>`
+
+```diff
+ pub struct NamespaceScope<T: Config> {
++    pub recipient: T::AccountId,
+     pub paths: BoundedBTreeMap<
+         Option<PermissionId>,
+         BoundedBTreeSet<NamespacePath, T::MaxNamespacesPerPermission>,
+         T::MaxNamespacesPerPermission,
+     >,
+ }
+```
+
+Similar to curator permissions, namespace permissions now explicitly track their recipient and support hierarchical path delegation through the optional PermissionId structure.
+
+## Behavior Changes
+
+### Permission Recipients Management
+
+**What changed**: Permission contracts no longer store a single recipient in the main contract structure. Instead, recipients are managed within each permission scope type, allowing for multiple recipients in emission permissions and explicit recipient tracking in curator and namespace permissions.
+
+**Why it matters**: This change enables more flexible permission models, particularly for emission permissions where multiple accounts can receive distributions from a single permission contract. It also provides clearer separation of concerns between permission metadata and scope-specific recipient management.
+
+**Migration needed**: Existing permission contracts are automatically migrated during runtime upgrade. Client applications that previously relied on the `recipient` field in events or contract queries must be updated to extract recipient information from the appropriate scope structure.
+
+*Tests*: The migration is validated through comprehensive tests in `pallets/permission0/src/migrations.rs` that ensure all existing permissions are correctly transformed and all storage indices are properly updated.
+
+*Cross-pallet impact*: Changes affect any pallet that queries permission contracts, though the API layer abstracts most of these changes from external consumers.
+
+### Emission Permission Weight Management
+
+**What changed**: Emission permissions now support designated `weight_setter` and `recipient_manager` accounts that can modify distribution parameters without requiring the original delegator's signature. The permission validation logic checks these manager accounts when processing updates.
+
+**Why it matters**: This enables delegated management of emission streams where the original permission creator can designate trusted accounts to handle operational aspects like weight adjustments or recipient list management. This is particularly useful for automated systems or multi-signature scenarios.
+
+**Migration needed**: Existing emission permissions will have `None` values for the new manager fields and continue to work with delegator-only management. New permissions can optionally specify managers during creation.
+
+*Tests*: Manager functionality is validated through permission update tests that verify proper access control for different management roles.
+
+*Cross-pallet impact*: The emission0 pallet can leverage these new management capabilities for more flexible weight control delegation scenarios.
+
+### Permission Index Management
+
+**What changed**: The permission indexing system has been redesigned to handle multiple recipients per permission contract. The new system maintains separate indices for delegators and participants (recipients), with proper cleanup when permissions are modified or revoked.
+
+**Why it matters**: This ensures that permission queries remain efficient even with the new multi-recipient model, and that storage cleanup properly handles all affected accounts when permissions change.
+
+**Migration needed**: The migration automatically rebuilds all permission indices using the new structure. No client-side changes are required.
+
+*Tests*: Index management is validated through migration tests that verify index consistency before and after the upgrade, including edge cases with complex permission hierarchies.
+
+*Cross-pallet impact*: Any pallet querying permissions by recipient will benefit from the improved index structure, with better performance for multi-recipient scenarios.

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
           pkgs.python310
           # Subxt CLI for metadata handling
           pkgs.subxt
+          pkgs.cargo-nextest
           # # Code coverage tool
           # pkgs.cargo-llvm-cov # marked as broken
         ];
@@ -59,7 +60,17 @@
         checks = pkgs.mkShell {
           pre-commit-check = pre-commit-hooks.lib.${system}.run {
             src = ./.;
-            hooks = { rustfmt.enable = true; };
+            hooks = {
+               rustfmt.enable = true;
+
+               push = {
+                 enable = true;
+                 name = "Tests & Stuff";
+                 entry = "just test";
+                 pass_filenames = false;
+                 stages = ["pre-push"];
+               };
+            };
           };
         };
 

--- a/justfile
+++ b/justfile
@@ -10,11 +10,11 @@ build-testnet:
 
 # Development
 
-check:
+check: fmt
   cargo clippy --tests
 
-test:
-  cargo test
+test: check
+  cargo nextest run
 
 fmt:
   cargo fmt

--- a/pallets/faucet/tests/faucet.rs
+++ b/pallets/faucet/tests/faucet.rs
@@ -232,7 +232,7 @@ impl pallet_governance::Config for Test {
 
 parameter_types! {
     pub const PermissionPalletId: PalletId = PalletId(*b"torusper");
-    pub const MaxTargetsPerPermission: u32 = 100;
+    pub const MaxRecipientsPerPermission: u32 = 100;
     pub const MaxStreamsPerPermission: u32 = 100;
     pub const MaxRevokersPerPermission: u32 = 10;
     pub const MaxControllersPerPermission: u32 = 10;
@@ -250,7 +250,7 @@ impl pallet_permission0::Config for Test {
 
     type Torus = Torus0;
 
-    type MaxTargetsPerPermission = MaxTargetsPerPermission;
+    type MaxRecipientsPerPermission = MaxRecipientsPerPermission;
 
     type MaxStreamsPerPermission = MaxStreamsPerPermission;
 

--- a/pallets/permission0/api/src/lib.rs
+++ b/pallets/permission0/api/src/lib.rs
@@ -6,8 +6,7 @@ use polkadot_sdk::{
     frame_support::dispatch::DispatchResult,
     sp_core::{H256, blake2_256},
     sp_runtime::{DispatchError, Percent},
-    sp_std::collections::btree_map::BTreeMap,
-    sp_std::vec::Vec,
+    sp_std::{collections::btree_map::BTreeMap, vec::Vec},
 };
 use scale_info::TypeInfo;
 
@@ -106,13 +105,14 @@ pub trait Permission0EmissionApi<AccountId, Origin, BlockNumber, Balance, Negati
     #[allow(clippy::too_many_arguments)]
     fn delegate_emission_permission(
         delegator: AccountId,
-        recipient: AccountId,
+        recipients: Vec<(AccountId, u16)>,
         allocation: EmissionAllocation<Balance>,
-        targets: Vec<(AccountId, u16)>,
         distribution: DistributionControl<Balance, BlockNumber>,
         duration: PermissionDuration<BlockNumber>,
         revocation: RevocationTerms<AccountId, BlockNumber>,
         enforcement: EnforcementAuthority<AccountId>,
+        recipient_manager: Option<AccountId>,
+        weight_setter: Option<AccountId>,
     ) -> Result<PermissionId, DispatchError>;
 
     /// Accumulate emissions for an agent with permissions

--- a/pallets/permission0/src/benchmarking.rs
+++ b/pallets/permission0/src/benchmarking.rs
@@ -31,14 +31,11 @@ mod benchmarks {
     fn delegate_emission_permission() {
         let delegator: T::AccountId = account("delegator", 0, 0);
         let recipient: T::AccountId = account("recipient", 1, 0);
-        let target: T::AccountId = account("Target", 2, 0);
 
         T::Torus::force_register_agent(&delegator, b"delegator".to_vec(), vec![], vec![])
             .expect("failed to register delegator");
         T::Torus::force_register_agent(&recipient, b"recipient".to_vec(), vec![], vec![])
             .expect("failed to register recipient");
-        T::Torus::force_register_agent(&target, b"target".to_vec(), vec![], vec![])
-            .expect("failed to register target");
 
         let amount = 10_000_000u32.into();
         let _ = <T::Currency>::deposit_creating(&delegator, amount);
@@ -46,7 +43,7 @@ mod benchmarks {
         let stream_id: StreamId = [0; 32].into();
         let streams = BTreeMap::from([(stream_id, Percent::from_percent(30))]);
         let allocation = EmissionAllocation::Streams(streams.try_into().unwrap());
-        let targets = bounded_btree_map![target => 100];
+        let recipients = bounded_btree_map![recipient => 100];
         let distribution = DistributionControl::Manual;
         let duration = PermissionDuration::Indefinite;
         let revocation = RevocationTerms::RevocableByDelegator;
@@ -55,13 +52,14 @@ mod benchmarks {
         #[extrinsic_call]
         delegate_emission_permission(
             RawOrigin::Signed(delegator),
-            recipient,
+            recipients,
             allocation,
-            targets,
             distribution,
             duration,
             revocation,
             enforcement,
+            None,
+            None,
         )
     }
 
@@ -69,14 +67,11 @@ mod benchmarks {
     fn revoke_permission() {
         let delegator: T::AccountId = account("delegator", 0, 0);
         let recipient: T::AccountId = account("recipient", 1, 0);
-        let target: T::AccountId = account("Target", 2, 0);
 
         T::Torus::force_register_agent(&delegator, b"delegator".to_vec(), vec![], vec![])
             .expect("failed to register delegator");
         T::Torus::force_register_agent(&recipient, b"recipient".to_vec(), vec![], vec![])
             .expect("failed to register recipient");
-        T::Torus::force_register_agent(&target, b"target".to_vec(), vec![], vec![])
-            .expect("failed to register target");
 
         let amount = 10_000_000u32.into();
         let _ = <T::Currency>::deposit_creating(&delegator, amount);
@@ -84,16 +79,16 @@ mod benchmarks {
         let stream_id: StreamId = [0; 32].into();
         let streams = BTreeMap::from([(stream_id, Percent::from_percent(30))]);
         let allocation = EmissionAllocation::Streams(streams.try_into().unwrap());
-        let targets = bounded_btree_map![target => 100];
+        let recipients = bounded_btree_map![recipient => 100];
         let permission_id = ext::emission_impl::delegate_emission_permission_impl::<T>(
             delegator.clone(),
-            recipient,
+            recipients,
             allocation,
-            targets,
             DistributionControl::Manual,
             PermissionDuration::Indefinite,
             RevocationTerms::RevocableByDelegator,
             EnforcementAuthority::None,
+            None,
             None,
         )
         .expect("failed to delegate permission");
@@ -106,14 +101,11 @@ mod benchmarks {
     fn execute_permission() {
         let delegator: T::AccountId = account("delegator", 0, 0);
         let recipient: T::AccountId = account("recipient", 1, 0);
-        let target: T::AccountId = account("Target", 2, 0);
 
         T::Torus::force_register_agent(&delegator, b"delegator".to_vec(), vec![], vec![])
             .expect("failed to register delegator");
         T::Torus::force_register_agent(&recipient, b"recipient".to_vec(), vec![], vec![])
             .expect("failed to register recipient");
-        T::Torus::force_register_agent(&target, b"target".to_vec(), vec![], vec![])
-            .expect("failed to register target");
 
         // Fund delegator
         let amount = 10_000_000u32.into();
@@ -123,17 +115,17 @@ mod benchmarks {
         let stream_id: StreamId = [0; 32].into();
         let streams = BTreeMap::from([(stream_id, Percent::from_percent(30))]);
         let allocation = EmissionAllocation::Streams(streams.try_into().unwrap());
-        let targets = bounded_btree_map![target => 100];
+        let recipients = bounded_btree_map![recipient => 100];
 
         let permission_id = ext::emission_impl::delegate_emission_permission_impl::<T>(
             delegator.clone(),
-            recipient,
+            recipients,
             allocation,
-            targets,
             DistributionControl::Manual,
             PermissionDuration::Indefinite,
             RevocationTerms::RevocableByDelegator,
             EnforcementAuthority::None,
+            None,
             None,
         )
         .expect("failed to delegate permission");
@@ -148,14 +140,11 @@ mod benchmarks {
     fn toggle_permission_accumulation() {
         let delegator: T::AccountId = account("delegator", 0, 0);
         let recipient: T::AccountId = account("recipient", 1, 0);
-        let target: T::AccountId = account("Target", 2, 0);
 
         T::Torus::force_register_agent(&delegator, b"delegator".to_vec(), vec![], vec![])
             .expect("failed to register delegator");
         T::Torus::force_register_agent(&recipient, b"recipient".to_vec(), vec![], vec![])
             .expect("failed to register recipient");
-        T::Torus::force_register_agent(&target, b"target".to_vec(), vec![], vec![])
-            .expect("failed to register target");
 
         // Fund delegator
         let amount = 10_000_000u32.into();
@@ -165,17 +154,17 @@ mod benchmarks {
         let stream_id: StreamId = [0; 32].into();
         let streams = BTreeMap::from([(stream_id, Percent::from_percent(30))]);
         let allocation = EmissionAllocation::Streams(streams.try_into().unwrap());
-        let targets = bounded_btree_map![target => 100];
+        let recipients = bounded_btree_map![recipient => 100];
 
         let permission_id = ext::emission_impl::delegate_emission_permission_impl::<T>(
             delegator.clone(),
-            recipient,
+            recipients,
             allocation,
-            targets,
             DistributionControl::Manual,
             PermissionDuration::Indefinite,
             RevocationTerms::RevocableByDelegator,
             EnforcementAuthority::None,
+            None,
             None,
         )
         .expect("failed to delegate permission");
@@ -188,7 +177,6 @@ mod benchmarks {
     fn enforcement_execute_permission() {
         let delegator: T::AccountId = account("delegator", 0, 0);
         let recipient: T::AccountId = account("recipient", 1, 0);
-        let target: T::AccountId = account("Target", 2, 0);
         let controller: T::AccountId = account("Controller", 3, 0);
 
         // Register agents
@@ -196,8 +184,6 @@ mod benchmarks {
             .expect("failed to register delegator");
         T::Torus::force_register_agent(&recipient, b"recipient".to_vec(), vec![], vec![])
             .expect("failed to register recipient");
-        T::Torus::force_register_agent(&target, b"target".to_vec(), vec![], vec![])
-            .expect("failed to register target");
 
         // Fund delegator
         let amount = 10_000_000u32.into();
@@ -207,7 +193,7 @@ mod benchmarks {
         let stream_id: StreamId = [0; 32].into();
         let streams = BTreeMap::from([(stream_id, Percent::from_percent(30))]);
         let allocation = EmissionAllocation::Streams(streams.try_into().unwrap());
-        let targets = bounded_btree_map![target => 100];
+        let recipients = bounded_btree_map![recipient => 100];
         let controllers = vec![controller.clone()].try_into().unwrap();
 
         let enforcement = EnforcementAuthority::ControlledBy {
@@ -217,13 +203,13 @@ mod benchmarks {
 
         let permission_id = ext::emission_impl::delegate_emission_permission_impl::<T>(
             delegator.clone(),
-            recipient,
+            recipients,
             allocation,
-            targets,
             DistributionControl::Manual,
             PermissionDuration::Indefinite,
             RevocationTerms::RevocableByDelegator,
             enforcement,
+            None,
             None,
         )
         .expect("failed to delegate permission");
@@ -238,7 +224,6 @@ mod benchmarks {
     fn set_enforcement_authority() {
         let delegator: T::AccountId = account("delegator", 0, 0);
         let recipient: T::AccountId = account("recipient", 1, 0);
-        let target: T::AccountId = account("Target", 2, 0);
         let controller1: T::AccountId = account("Controller1", 3, 0);
         let controller2: T::AccountId = account("Controller2", 4, 0);
 
@@ -246,8 +231,6 @@ mod benchmarks {
             .expect("failed to register delegator");
         T::Torus::force_register_agent(&recipient, b"recipient".to_vec(), vec![], vec![])
             .expect("failed to register recipient");
-        T::Torus::force_register_agent(&target, b"target".to_vec(), vec![], vec![])
-            .expect("failed to register target");
 
         let amount = 10_000_000u32.into();
         let _ = <T::Currency>::deposit_creating(&delegator, amount);
@@ -255,17 +238,17 @@ mod benchmarks {
         let stream_id: StreamId = [0; 32].into();
         let streams = BTreeMap::from([(stream_id, Percent::from_percent(30))]);
         let allocation = EmissionAllocation::Streams(streams.try_into().unwrap());
-        let targets = bounded_btree_map![target => 100];
+        let recipients = bounded_btree_map![recipient => 100];
 
         let permission_id = ext::emission_impl::delegate_emission_permission_impl::<T>(
             delegator.clone(),
-            recipient,
+            recipients,
             allocation,
-            targets,
             DistributionControl::Manual,
             PermissionDuration::Indefinite,
             RevocationTerms::RevocableByDelegator,
             EnforcementAuthority::None,
+            None,
             None,
         )
         .expect("failed to delegate permission");

--- a/pallets/permission0/src/lib.rs
+++ b/pallets/permission0/src/lib.rs
@@ -66,7 +66,7 @@ pub mod pallet {
 
         /// Maximum number of targets per permission.
         #[pallet::constant]
-        type MaxTargetsPerPermission: Get<u32>;
+        type MaxRecipientsPerPermission: Get<u32>;
 
         /// Maximum number of delegated streams per permission.
         #[pallet::constant]
@@ -112,7 +112,7 @@ pub mod pallet {
         _,
         Identity,
         (T::AccountId, T::AccountId),
-        BoundedBTreeSet<PermissionId, T::MaxTargetsPerPermission>,
+        BoundedBTreeSet<PermissionId, T::MaxRecipientsPerPermission>,
         ValueQuery,
     >;
 
@@ -122,7 +122,7 @@ pub mod pallet {
         _,
         Identity,
         T::AccountId,
-        BoundedBTreeSet<PermissionId, T::MaxTargetsPerPermission>,
+        BoundedBTreeSet<PermissionId, T::MaxRecipientsPerPermission>,
         ValueQuery,
     >;
 
@@ -132,7 +132,7 @@ pub mod pallet {
         _,
         Identity,
         T::AccountId,
-        BoundedBTreeSet<PermissionId, T::MaxTargetsPerPermission>,
+        BoundedBTreeSet<PermissionId, T::MaxRecipientsPerPermission>,
         ValueQuery,
     >;
 
@@ -316,6 +316,8 @@ pub mod pallet {
         NotEnoughInstances,
         /// Too many children for a permission.
         TooManyChildren,
+        /// Emission managers must have up to two entries and always contain the delegator,
+        InvalidEmissionManagers,
         /// Revocation terms are too strong for a permission re-delegation.
         RevocationTermsTooStrong,
         /// Too many curator permissions being delegated in a single permission.
@@ -338,7 +340,7 @@ pub mod pallet {
         #[pallet::weight(T::WeightInfo::delegate_emission_permission())]
         pub fn delegate_emission_permission(
             origin: OriginFor<T>,
-            recipients: BoundedBTreeMap<T::AccountId, u16, T::MaxTargetsPerPermission>,
+            recipients: BoundedBTreeMap<T::AccountId, u16, T::MaxRecipientsPerPermission>,
             allocation: EmissionAllocation<T>,
             distribution: DistributionControl<T>,
             duration: PermissionDuration<T>,
@@ -491,7 +493,9 @@ pub mod pallet {
         pub fn update_emission_permission(
             origin: OriginFor<T>,
             permission_id: PermissionId,
-            new_recipients: Option<BoundedBTreeMap<T::AccountId, u16, T::MaxTargetsPerPermission>>,
+            new_recipients: Option<
+                BoundedBTreeMap<T::AccountId, u16, T::MaxRecipientsPerPermission>,
+            >,
             new_streams: Option<BoundedBTreeMap<StreamId, Percent, T::MaxStreamsPerPermission>>,
             new_distribution_control: Option<DistributionControl<T>>,
             new_recipient_manager: Option<Option<T::AccountId>>,

--- a/pallets/permission0/src/lib.rs
+++ b/pallets/permission0/src/lib.rs
@@ -21,7 +21,6 @@ pub use pallet_permission0_api::{StreamId, generate_root_stream_id};
 
 use polkadot_sdk::{
     frame_support::{
-        BoundedVec,
         dispatch::DispatchResult,
         pallet_prelude::*,
         traits::{Currency, Get, ReservableCurrency},
@@ -39,7 +38,7 @@ pub mod pallet {
 
     use super::*;
 
-    const STORAGE_VERSION: StorageVersion = StorageVersion::new(5);
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(6);
 
     /// Configure the pallet by specifying the parameters and types on which it depends.
     #[pallet::config]
@@ -113,7 +112,7 @@ pub mod pallet {
         _,
         Identity,
         (T::AccountId, T::AccountId),
-        BoundedVec<PermissionId, T::MaxTargetsPerPermission>,
+        BoundedBTreeSet<PermissionId, T::MaxTargetsPerPermission>,
         ValueQuery,
     >;
 
@@ -123,7 +122,7 @@ pub mod pallet {
         _,
         Identity,
         T::AccountId,
-        BoundedVec<PermissionId, T::MaxTargetsPerPermission>,
+        BoundedBTreeSet<PermissionId, T::MaxTargetsPerPermission>,
         ValueQuery,
     >;
 
@@ -133,7 +132,7 @@ pub mod pallet {
         _,
         Identity,
         T::AccountId,
-        BoundedVec<PermissionId, T::MaxTargetsPerPermission>,
+        BoundedBTreeSet<PermissionId, T::MaxTargetsPerPermission>,
         ValueQuery,
     >;
 
@@ -177,20 +176,17 @@ pub mod pallet {
         /// Permission delegated from delegator to recipient with ID
         PermissionDelegated {
             delegator: T::AccountId,
-            recipient: T::AccountId,
             permission_id: PermissionId,
         },
         /// Permission revoked with ID
         PermissionRevoked {
             delegator: T::AccountId,
-            recipient: T::AccountId,
             revoked_by: Option<T::AccountId>,
             permission_id: PermissionId,
         },
         /// Permission expired with ID
         PermissionExpired {
             delegator: T::AccountId,
-            recipient: T::AccountId,
             permission_id: PermissionId,
         },
         /// Permission accumulation state toggled
@@ -342,26 +338,27 @@ pub mod pallet {
         #[pallet::weight(T::WeightInfo::delegate_emission_permission())]
         pub fn delegate_emission_permission(
             origin: OriginFor<T>,
-            recipient: T::AccountId,
+            recipients: BoundedBTreeMap<T::AccountId, u16, T::MaxTargetsPerPermission>,
             allocation: EmissionAllocation<T>,
-            targets: BoundedBTreeMap<T::AccountId, u16, T::MaxTargetsPerPermission>,
             distribution: DistributionControl<T>,
             duration: PermissionDuration<T>,
             revocation: RevocationTerms<T>,
             enforcement: EnforcementAuthority<T>,
+            recipient_manager: Option<T::AccountId>,
+            weight_setter: Option<T::AccountId>,
         ) -> DispatchResult {
             let delegator = ensure_signed(origin)?;
 
             ext::emission_impl::delegate_emission_permission_impl::<T>(
                 delegator,
-                recipient,
+                recipients,
                 allocation,
-                targets,
                 distribution,
                 duration,
                 revocation,
                 enforcement,
-                None,
+                recipient_manager,
+                weight_setter,
             )?;
 
             Ok(())
@@ -494,16 +491,20 @@ pub mod pallet {
         pub fn update_emission_permission(
             origin: OriginFor<T>,
             permission_id: PermissionId,
-            new_targets: BoundedBTreeMap<T::AccountId, u16, T::MaxTargetsPerPermission>,
+            new_recipients: Option<BoundedBTreeMap<T::AccountId, u16, T::MaxTargetsPerPermission>>,
             new_streams: Option<BoundedBTreeMap<StreamId, Percent, T::MaxStreamsPerPermission>>,
             new_distribution_control: Option<DistributionControl<T>>,
+            new_recipient_manager: Option<Option<T::AccountId>>,
+            new_weight_setter: Option<Option<T::AccountId>>,
         ) -> DispatchResult {
             ext::emission_impl::update_emission_permission(
                 origin,
                 permission_id,
-                new_targets,
+                new_recipients,
                 new_streams,
                 new_distribution_control,
+                new_recipient_manager,
+                new_weight_setter,
             )?;
 
             Ok(())
@@ -545,65 +546,4 @@ fn get_total_allocated_percentage<T: Config>(
         .fold(Percent::zero(), |acc, percentage| {
             acc.saturating_add(percentage)
         })
-}
-
-/// Update storage indices when creating a new permission
-fn update_permission_indices<T: Config>(
-    delegator: &T::AccountId,
-    recipient: &T::AccountId,
-    permission_id: PermissionId,
-) -> Result<(), DispatchError> {
-    // Update (delegator, recipient) -> [permission_id] mapping
-    PermissionsByParticipants::<T>::try_mutate(
-        (delegator.clone(), recipient.clone()),
-        |permissions| -> Result<(), DispatchError> {
-            permissions
-                .try_push(permission_id)
-                .map_err(|_| Error::<T>::TooManyTargets)?;
-            Ok(())
-        },
-    )?;
-
-    // Update delegator -> [permission_id] mapping
-    PermissionsByDelegator::<T>::try_mutate(
-        delegator.clone(),
-        |permissions| -> Result<(), DispatchError> {
-            permissions
-                .try_push(permission_id)
-                .map_err(|_| Error::<T>::TooManyTargets)?;
-            Ok(())
-        },
-    )?;
-
-    // Update recipient -> [permission_id] mapping
-    PermissionsByRecipient::<T>::try_mutate(
-        recipient.clone(),
-        |permissions| -> Result<(), DispatchError> {
-            permissions
-                .try_push(permission_id)
-                .map_err(|_| Error::<T>::TooManyTargets)?;
-            Ok(())
-        },
-    )?;
-
-    Ok(())
-}
-
-/// Remove a permission from storage indices
-fn remove_permission_from_indices<T: Config>(
-    delegator: &T::AccountId,
-    recipient: &T::AccountId,
-    permission_id: PermissionId,
-) {
-    PermissionsByParticipants::<T>::mutate((delegator.clone(), recipient.clone()), |permissions| {
-        permissions.retain(|id| *id != permission_id);
-    });
-
-    PermissionsByDelegator::<T>::mutate(delegator, |permissions| {
-        permissions.retain(|id| *id != permission_id);
-    });
-
-    PermissionsByRecipient::<T>::mutate(recipient, |permissions| {
-        permissions.retain(|id| *id != permission_id);
-    });
 }

--- a/pallets/permission0/src/migrations.rs
+++ b/pallets/permission0/src/migrations.rs
@@ -1,1 +1,350 @@
+pub mod v6 {
+    use polkadot_sdk::{
+        frame_support::{migrations::VersionedMigration, traits::UncheckedOnRuntimeUpgrade},
+        sp_tracing::{error, info, warn},
+        sp_weights::Weight,
+    };
 
+    use crate::{
+        Config, EmissionScope, Pallet, PermissionContract, PermissionScope, Permissions,
+        PermissionsByDelegator, PermissionsByParticipants, PermissionsByRecipient,
+        permission::{CuratorScope, NamespaceScope},
+        permission::{add_permission_indices, remove_permission_from_indices},
+    };
+
+    pub type Migration<T, W> = VersionedMigration<5, 6, MigrateToV6<T>, Pallet<T>, W>;
+    pub struct MigrateToV6<T>(core::marker::PhantomData<T>);
+
+    mod old_storage {
+        use codec::{Decode, Encode, MaxEncodedLen};
+        use polkadot_sdk::{
+            frame_support::Identity,
+            frame_support_procedural::storage_alias,
+            polkadot_sdk_frame::prelude::BlockNumberFor,
+            sp_runtime::{BoundedBTreeMap, BoundedBTreeSet},
+        };
+        use scale_info::TypeInfo;
+
+        use crate::{Config, DistributionControl, EmissionAllocation, Pallet, PermissionId};
+
+        #[storage_alias]
+        pub type Permissions<T: Config> =
+            StorageMap<Pallet<T>, Identity, PermissionId, OldPermissionContract<T>>;
+
+        #[derive(Encode, Decode, TypeInfo, MaxEncodedLen)]
+        #[scale_info(skip_type_params(T))]
+        pub struct OldEmissionScope<T: Config> {
+            pub allocation: EmissionAllocation<T>,
+            pub distribution: DistributionControl<T>,
+            pub targets: BoundedBTreeMap<T::AccountId, u16, T::MaxTargetsPerPermission>,
+            pub accumulating: bool,
+        }
+
+        #[derive(Encode, Decode, TypeInfo, MaxEncodedLen)]
+        #[scale_info(skip_type_params(T))]
+        pub struct OldCuratorScope<T: Config> {
+            pub flags: BoundedBTreeMap<
+                Option<PermissionId>,
+                crate::CuratorPermissions,
+                T::MaxCuratorSubpermissionsPerPermission,
+            >,
+            pub cooldown: Option<BlockNumberFor<T>>,
+        }
+
+        #[derive(Encode, Decode, TypeInfo, MaxEncodedLen)]
+        #[scale_info(skip_type_params(T))]
+        pub struct OldNamespaceScope<T: Config> {
+            pub paths: BoundedBTreeMap<
+                Option<PermissionId>,
+                BoundedBTreeSet<pallet_torus0_api::NamespacePath, T::MaxNamespacesPerPermission>,
+                T::MaxNamespacesPerPermission,
+            >,
+        }
+
+        #[derive(Encode, Decode, TypeInfo, MaxEncodedLen)]
+        #[scale_info(skip_type_params(T))]
+        pub enum OldPermissionScope<T: Config> {
+            Emission(OldEmissionScope<T>),
+            Curator(OldCuratorScope<T>),
+            Namespace(OldNamespaceScope<T>),
+        }
+
+        #[derive(Encode, Decode, TypeInfo, MaxEncodedLen)]
+        #[scale_info(skip_type_params(T))]
+        pub struct OldPermissionContract<T: Config> {
+            pub delegator: T::AccountId,
+            pub recipient: T::AccountId,
+            pub scope: OldPermissionScope<T>,
+            pub duration: crate::permission::PermissionDuration<T>,
+            pub revocation: crate::RevocationTerms<T>,
+            pub enforcement: crate::permission::EnforcementAuthority<T>,
+            pub last_execution: Option<BlockNumberFor<T>>,
+            pub execution_count: u32,
+            pub max_instances: u32,
+            pub children: polkadot_sdk::sp_runtime::BoundedBTreeSet<
+                PermissionId,
+                T::MaxChildrenPerPermission,
+            >,
+            pub created_at: BlockNumberFor<T>,
+        }
+    }
+
+    impl<T: Config> UncheckedOnRuntimeUpgrade for MigrateToV6<T> {
+        fn on_runtime_upgrade() -> Weight {
+            let mut migrated_count = 0u32;
+            let mut emission_permissions_updated = 0u32;
+            let mut curator_permissions_updated = 0u32;
+            let mut namespace_permissions_updated = 0u32;
+
+            for (permission_id, old_contract) in old_storage::Permissions::<T>::iter() {
+                let new_scope = match old_contract.scope {
+                    old_storage::OldPermissionScope::Emission(old_emission) => {
+                        emission_permissions_updated =
+                            emission_permissions_updated.saturating_add(1);
+
+                        // For emission permissions, we need to update storage indices:
+                        // 1. Remove the old recipient index (permission recipient)
+                        // 2. Add indices for all the emission targets
+
+                        // Remove old recipient index
+                        remove_permission_from_indices::<T>(
+                            &old_contract.delegator,
+                            core::iter::once(&old_contract.recipient),
+                            permission_id,
+                        );
+
+                        let new_emission = EmissionScope::<T> {
+                            recipients: old_emission.targets, // Field renamed from targets to recipients
+                            allocation: old_emission.allocation,
+                            distribution: old_emission.distribution,
+                            accumulating: old_emission.accumulating,
+                            // New manager fields introduced in v6
+                            recipient_manager: None,
+                            weight_setter: None,
+                        };
+
+                        // Add new indices for all emission targets
+                        if let Err(e) = add_permission_indices::<T>(
+                            &old_contract.delegator,
+                            new_emission.recipients.keys(),
+                            permission_id,
+                        ) {
+                            error!(
+                                "Failed to add permission indices for emission permission {permission_id:?}: {e:?}"
+                            );
+                        }
+
+                        PermissionScope::Emission(new_emission)
+                    }
+                    old_storage::OldPermissionScope::Curator(old_curator) => {
+                        curator_permissions_updated = curator_permissions_updated.saturating_add(1);
+
+                        let new_curator = crate::permission::CuratorScope::<T> {
+                            recipient: old_contract.recipient.clone(), // Add recipient field from contract
+                            flags: old_curator.flags,
+                            cooldown: old_curator.cooldown,
+                        };
+
+                        PermissionScope::Curator(new_curator)
+                    }
+                    old_storage::OldPermissionScope::Namespace(old_namespace) => {
+                        namespace_permissions_updated =
+                            namespace_permissions_updated.saturating_add(1);
+
+                        let new_namespace = crate::permission::NamespaceScope::<T> {
+                            recipient: old_contract.recipient.clone(), // Add recipient field from contract
+                            paths: old_namespace.paths,
+                        };
+
+                        PermissionScope::Namespace(new_namespace)
+                    }
+                };
+                let new_contract = PermissionContract::<T> {
+                    delegator: old_contract.delegator,
+                    scope: new_scope,
+                    duration: old_contract.duration,
+                    revocation: old_contract.revocation,
+                    enforcement: old_contract.enforcement,
+                    last_execution: old_contract.last_execution,
+                    execution_count: old_contract.execution_count,
+                    children: old_contract.children,
+                    created_at: old_contract.created_at,
+                    max_instances: old_contract.max_instances,
+                };
+
+                crate::Permissions::<T>::set(permission_id, Some(new_contract));
+                migrated_count = migrated_count.saturating_add(1);
+            }
+
+            info!(
+                "Permission0 migration v5→v6 completed: {migrated_count} total permissions migrated \
+| Emission: {emission_permissions_updated} (targets→recipients, manager fields added) \
+| Curator: {curator_permissions_updated} (recipient field added) \
+| Namespace: {namespace_permissions_updated} (recipient field added)",
+            );
+
+            check_all_indices_consistency::<T>();
+
+            Weight::zero()
+        }
+    }
+
+    /// Check consistency of all permission indices after migration
+    fn check_all_indices_consistency<T: Config>() {
+        info!("Starting permission0 index consistency checks...");
+
+        let mut total_inconsistencies = 0u32;
+        total_inconsistencies =
+            total_inconsistencies.saturating_add(check_delegator_indices_consistency::<T>());
+        total_inconsistencies =
+            total_inconsistencies.saturating_add(check_recipient_indices_consistency::<T>());
+        total_inconsistencies =
+            total_inconsistencies.saturating_add(check_participant_indices_consistency::<T>());
+
+        if total_inconsistencies == 0 {
+            info!("All permission0 indices are consistent!");
+        } else {
+            error!("Found {total_inconsistencies} total index inconsistencies in permission0!");
+        }
+    }
+
+    /// Check that all permissions in delegator indices exist and have correct delegator
+    fn check_delegator_indices_consistency<T: Config>() -> u32 {
+        let mut inconsistencies = 0u32;
+
+        for (delegator, permission_ids) in PermissionsByDelegator::<T>::iter() {
+            for permission_id in permission_ids.iter() {
+                if let Some(contract) = Permissions::<T>::get(permission_id) {
+                    if contract.delegator != delegator {
+                        error!(
+                            "Delegator index inconsistency: Permission {permission_id:?} \
+                            indexed under delegator {delegator:?} but actual delegator is {:?}",
+                            contract.delegator
+                        );
+                        inconsistencies = inconsistencies.saturating_add(1);
+                    }
+                } else {
+                    error!(
+                        "Delegator index inconsistency: Permission {permission_id:?} \
+                        indexed under delegator {delegator:?} but permission doesn't exist"
+                    );
+                    inconsistencies = inconsistencies.saturating_add(1);
+                }
+            }
+        }
+
+        if inconsistencies > 0 {
+            warn!("Found {inconsistencies} delegator index inconsistencies");
+        } else {
+            info!("Delegator indices are consistent");
+        }
+
+        inconsistencies
+    }
+
+    /// Check that all permissions in recipient indices exist and recipient is listed in the permission scope
+    fn check_recipient_indices_consistency<T: Config>() -> u32 {
+        let mut inconsistencies = 0u32;
+
+        for (recipient, permission_ids) in PermissionsByRecipient::<T>::iter() {
+            for permission_id in permission_ids.iter() {
+                if let Some(contract) = Permissions::<T>::get(permission_id) {
+                    let is_valid_recipient = match &contract.scope {
+                        PermissionScope::Emission(EmissionScope { recipients, .. }) => {
+                            recipients.contains_key(&recipient)
+                        }
+                        PermissionScope::Curator(CuratorScope {
+                            recipient: scope_recipient,
+                            ..
+                        })
+                        | PermissionScope::Namespace(NamespaceScope {
+                            recipient: scope_recipient,
+                            ..
+                        }) => scope_recipient == &recipient,
+                    };
+
+                    if !is_valid_recipient {
+                        error!(
+                            "Recipient index inconsistency: Permission {permission_id:?} \
+                            indexed under recipient {recipient:?} but recipient is not in the permission scope"
+                        );
+                        inconsistencies = inconsistencies.saturating_add(1);
+                    }
+                } else {
+                    error!(
+                        "Recipient index inconsistency: Permission {permission_id:?} \
+                        indexed under recipient {recipient:?} but permission doesn't exist"
+                    );
+                    inconsistencies = inconsistencies.saturating_add(1);
+                }
+            }
+        }
+
+        if inconsistencies > 0 {
+            warn!("Found {inconsistencies} recipient index inconsistencies");
+        } else {
+            info!("Recipient indices are consistent");
+        }
+
+        inconsistencies
+    }
+
+    /// Check that all permissions in participant indices exist and both participants are correct
+    fn check_participant_indices_consistency<T: Config>() -> u32 {
+        let mut inconsistencies = 0u32;
+
+        for ((delegator, recipient), permission_ids) in PermissionsByParticipants::<T>::iter() {
+            for permission_id in permission_ids.iter() {
+                if let Some(contract) = Permissions::<T>::get(permission_id) {
+                    if contract.delegator != delegator {
+                        error!(
+                            "Participant index inconsistency: Permission {permission_id:?} \
+                            indexed under delegator {delegator:?} but actual delegator is {:?}",
+                            contract.delegator
+                        );
+                        inconsistencies = inconsistencies.saturating_add(1);
+                        continue;
+                    }
+
+                    let is_valid_recipient = match &contract.scope {
+                        PermissionScope::Emission(EmissionScope { recipients, .. }) => {
+                            recipients.contains_key(&recipient)
+                        }
+                        PermissionScope::Curator(CuratorScope {
+                            recipient: scope_recipient,
+                            ..
+                        })
+                        | PermissionScope::Namespace(NamespaceScope {
+                            recipient: scope_recipient,
+                            ..
+                        }) => scope_recipient == &recipient,
+                    };
+
+                    if !is_valid_recipient {
+                        error!(
+                            "Participant index inconsistency: Permission {permission_id:?} \
+                            indexed under participant pair ({delegator:?}, {recipient:?}) \
+                            but recipient is not in the permission scope"
+                        );
+                        inconsistencies = inconsistencies.saturating_add(1);
+                    }
+                } else {
+                    error!(
+                        "Participant index inconsistency: Permission {permission_id:?} \
+                        indexed under participant pair ({delegator:?}, {recipient:?}) \
+                        but permission doesn't exist"
+                    );
+                    inconsistencies = inconsistencies.saturating_add(1);
+                }
+            }
+        }
+
+        if inconsistencies > 0 {
+            warn!("Found {inconsistencies} participant index inconsistencies");
+        } else {
+            info!("Participant indices are consistent");
+        }
+
+        inconsistencies
+    }
+}

--- a/pallets/permission0/src/permission/emission.rs
+++ b/pallets/permission0/src/permission/emission.rs
@@ -17,7 +17,7 @@ pub type StreamId = H256;
 #[scale_info(skip_type_params(T))]
 pub struct EmissionScope<T: Config> {
     /// Recipients of the emissions and its weights
-    pub recipients: BoundedBTreeMap<T::AccountId, u16, T::MaxTargetsPerPermission>,
+    pub recipients: BoundedBTreeMap<T::AccountId, u16, T::MaxRecipientsPerPermission>,
     /// What portion of emissions this permission applies to
     pub allocation: EmissionAllocation<T>,
     /// Distribution control parameters
@@ -26,10 +26,10 @@ pub struct EmissionScope<T: Config> {
     pub accumulating: bool,
     /// An account responsible for managing the recipients to this permission's streams.
     /// If left empty, the delegator will be
-    pub recipient_manager: Option<T::AccountId>,
+    pub recipient_managers: BoundedBTreeSet<T::AccountId, T::MaxControllersPerPermission>,
     /// An account responsible for updating the weights of existing recipients. Useful
     /// for third-party agents to manage how the streams will be distributed.
-    pub weight_setter: Option<T::AccountId>,
+    pub weight_setters: BoundedBTreeSet<T::AccountId, T::MaxControllersPerPermission>,
 }
 
 impl<T: Config> EmissionScope<T> {

--- a/pallets/permission0/tests/enforcement.rs
+++ b/pallets/permission0/tests/enforcement.rs
@@ -39,9 +39,8 @@ fn set_enforcement_authority_by_delegator() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             delegator,
-            recipient,
-            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             vec![(recipient, u16::MAX)],
+            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -115,9 +114,8 @@ fn toggle_accumulation_by_controller() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             delegator,
-            recipient,
-            pallet_permission0_api::EmissionAllocation::Streams(stream_percentages(delegator, 100)),
             vec![(recipient, u16::MAX)],
+            pallet_permission0_api::EmissionAllocation::Streams(stream_percentages(delegator, 100)),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -184,9 +182,8 @@ fn unauthorized_account_cannot_toggle() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             delegator,
-            recipient,
-            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             vec![(recipient, u16::MAX)],
+            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -231,9 +228,8 @@ fn enforcement_execute_permission() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             delegator,
-            recipient,
-            pallet_permission0_api::EmissionAllocation::Streams(stream_percentages(delegator, 100)),
             vec![(recipient, u16::MAX)],
+            pallet_permission0_api::EmissionAllocation::Streams(stream_percentages(delegator, 100)),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -276,9 +272,8 @@ fn unauthorized_cannot_enforcement_execute() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             delegator,
-            recipient,
-            pallet_permission0_api::EmissionAllocation::Streams(stream_percentages(delegator, 100)),
             vec![(recipient, u16::MAX)],
+            pallet_permission0_api::EmissionAllocation::Streams(stream_percentages(delegator, 100)),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -320,9 +315,8 @@ fn multi_controller_voting() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             delegator,
-            recipient,
-            pallet_permission0_api::EmissionAllocation::Streams(stream_percentages(delegator, 100)),
             vec![(recipient, u16::MAX)],
+            pallet_permission0_api::EmissionAllocation::Streams(stream_percentages(delegator, 100)),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -430,9 +424,8 @@ fn enforcement_cannot_execute_non_manual_distribution() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             delegator,
-            recipient,
-            pallet_permission0_api::EmissionAllocation::Streams(stream_percentages(delegator, 100)),
             vec![(recipient, u16::MAX)],
+            pallet_permission0_api::EmissionAllocation::Streams(stream_percentages(delegator, 100)),
             pallet_permission0_api::DistributionControl::Automatic(
                 MinAutoDistributionThreshold::get()
             ),

--- a/pallets/permission0/tests/fixed.rs
+++ b/pallets/permission0/tests/fixed.rs
@@ -14,9 +14,8 @@ fn fixed_fails_without_balance() {
         assert_err!(
             delegate_emission_permission(
                 agent_0,
-                agent_1,
+                vec![(agent_1, u16::MAX)],
                 pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
-                vec![(agent_0, u16::MAX)],
                 pallet_permission0_api::DistributionControl::Manual,
                 pallet_permission0_api::PermissionDuration::Indefinite,
                 pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -41,9 +40,8 @@ fn fixed_creates() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
+            vec![(agent_1, u16::MAX)],
             pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
-            vec![(agent_0, u16::MAX)],
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -70,9 +68,8 @@ fn fixed_reserves() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
+            vec![(agent_1, u16::MAX)],
             pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
-            vec![(agent_0, u16::MAX)],
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -104,9 +101,8 @@ fn fixed_manual_executes() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
-            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             vec![(agent_1, u16::MAX / 2), (agent_2, u16::MAX / 2)],
+            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -150,9 +146,8 @@ fn fixed_manual_executes_only_once() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
-            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             vec![(agent_1, u16::MAX / 2), (agent_2, u16::MAX / 2)],
+            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -200,9 +195,8 @@ fn fixed_at_block_executes() {
 
         let _ = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
-            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             vec![(agent_1, u16::MAX / 2), (agent_2, u16::MAX / 2)],
+            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             pallet_permission0_api::DistributionControl::AtBlock(20),
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,

--- a/pallets/permission0/tests/lifetime.rs
+++ b/pallets/permission0/tests/lifetime.rs
@@ -1,4 +1,4 @@
-use pallet_permission0::Error;
+use pallet_permission0::{Error, PermissionScope, Permissions};
 use polkadot_sdk::frame_support::assert_err;
 use test_utils::*;
 
@@ -19,11 +19,10 @@ fn manual_cant_execute_when_expires() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
-            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             vec![(agent_1, u16::MAX / 2), (agent_2, u16::MAX / 2)],
+            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             pallet_permission0_api::DistributionControl::Manual,
-            pallet_permission0_api::PermissionDuration::UntilBlock(1),
+            pallet_permission0_api::PermissionDuration::UntilBlock(2),
             pallet_permission0_api::RevocationTerms::Irrevocable,
             pallet_permission0_api::EnforcementAuthority::None,
         ));
@@ -54,9 +53,8 @@ fn irrevocable() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
-            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             vec![(agent_1, u16::MAX / 2), (agent_2, u16::MAX / 2)],
+            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -68,16 +66,18 @@ fn irrevocable() {
             pallet_permission0::Error::<Test>::NotAuthorizedToRevoke
         );
 
-        assert_err!(
-            Permission0::revoke_permission(get_origin(agent_2), permission_id),
-            pallet_permission0::Error::<Test>::NotAuthorizedToRevoke
-        );
-
         // should still be revocable by recipient
         assert_ok!(Permission0::revoke_permission(
             get_origin(agent_1),
             permission_id
-        ),);
+        ));
+
+        assert_ok!(Permission0::revoke_permission(
+            get_origin(agent_2),
+            permission_id
+        ));
+
+        assert!(!Permissions::<Test>::contains_key(permission_id));
     });
 }
 
@@ -94,13 +94,15 @@ fn revocable_by_delegator() {
         let agent_2 = 2;
         register_empty_agent(agent_2);
 
+        let agent_3 = 3;
+        register_empty_agent(agent_3);
+
         add_balance(agent_0, as_tors(10) + 1);
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
-            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             vec![(agent_1, u16::MAX / 2), (agent_2, u16::MAX / 2)],
+            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::RevocableByDelegator,
@@ -108,14 +110,32 @@ fn revocable_by_delegator() {
         ));
 
         assert_err!(
-            Permission0::revoke_permission(get_origin(agent_2), permission_id),
+            Permission0::revoke_permission(get_origin(agent_3), permission_id),
             pallet_permission0::Error::<Test>::NotAuthorizedToRevoke
+        );
+
+        assert_ok!(Permission0::revoke_permission(
+            get_origin(agent_2),
+            permission_id
+        ));
+
+        let permission = Permissions::<Test>::get(permission_id).unwrap();
+        let PermissionScope::Emission(scope) = permission.scope else {
+            panic!()
+        };
+
+        assert!(
+            scope.recipients.len() == 1
+                && scope.recipients.contains_key(&agent_1)
+                && !scope.recipients.contains_key(&agent_2)
         );
 
         assert_ok!(Permission0::revoke_permission(
             get_origin(agent_0),
             permission_id
         ),);
+
+        assert!(!Permissions::<Test>::contains_key(permission_id));
     });
 }
 
@@ -136,17 +156,16 @@ fn revocable_after_block() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
-            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             vec![(agent_1, u16::MAX / 2), (agent_2, u16::MAX / 2)],
+            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
-            pallet_permission0_api::RevocationTerms::RevocableAfter(1),
+            pallet_permission0_api::RevocationTerms::RevocableAfter(2),
             pallet_permission0_api::EnforcementAuthority::None,
         ));
 
         assert_err!(
-            Permission0::revoke_permission(get_origin(agent_2), permission_id),
+            Permission0::revoke_permission(get_origin(agent_0), permission_id),
             pallet_permission0::Error::<Test>::NotAuthorizedToRevoke
         );
 
@@ -155,7 +174,9 @@ fn revocable_after_block() {
         assert_ok!(Permission0::revoke_permission(
             get_origin(agent_0),
             permission_id
-        ),);
+        ));
+
+        assert!(!Permissions::<Test>::contains_key(permission_id));
     });
 }
 
@@ -174,9 +195,8 @@ fn revocable_by_arbiters() {
         let delegate_invalid = |accounts: &[AccountId], required_votes| {
             delegate_emission_permission(
                 agent_0,
-                agent_1,
-                pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
                 vec![(agent_1, u16::MAX / 2)],
+                pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
                 pallet_permission0_api::DistributionControl::Manual,
                 pallet_permission0_api::PermissionDuration::Indefinite,
                 pallet_permission0_api::RevocationTerms::RevocableByArbiters {
@@ -205,9 +225,8 @@ fn revocable_by_arbiters() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
-            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             vec![(agent_1, u16::MAX)],
+            pallet_permission0_api::EmissionAllocation::FixedAmount(as_tors(10)),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::RevocableByArbiters {

--- a/pallets/permission0/tests/namespace.rs
+++ b/pallets/permission0/tests/namespace.rs
@@ -36,7 +36,7 @@ fn get_last_delegated_permission_id(delegator: AccountId) -> PermissionId {
                 None
             }
         })
-        .last() // Get most recent
+        .next_back() // Get most recent
         .expect("No PermissionDelegated event found")
 }
 
@@ -80,7 +80,7 @@ fn get_permission_id_for_recipient(recipient: AccountId) -> PermissionId {
             _ => continue,
         }
     }
-    panic!("No permission found for recipient: {:?}", recipient);
+    panic!("No permission found for recipient: {recipient:?}");
 }
 
 fn register_agent(id: AccountId) {

--- a/pallets/permission0/tests/namespace.rs
+++ b/pallets/permission0/tests/namespace.rs
@@ -13,6 +13,76 @@ use polkadot_sdk::{
 };
 use test_utils::*;
 
+pub fn new_test_ext() -> polkadot_sdk::sp_io::TestExternalities {
+    new_test_ext_with_block(100)
+}
+
+// Helper to get the most recent permission ID from events
+fn get_last_delegated_permission_id(delegator: AccountId) -> PermissionId {
+    System::events()
+        .into_iter()
+        .filter_map(|record| {
+            if let RuntimeEvent::Permission0(pallet_permission0::Event::PermissionDelegated {
+                delegator: event_delegator,
+                permission_id,
+            }) = record.event
+            {
+                if event_delegator == delegator {
+                    Some(permission_id)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .last() // Get most recent
+        .expect("No PermissionDelegated event found")
+}
+
+// Helper to get all permission IDs for a delegator from events (in chronological order)
+fn get_all_delegated_permission_ids(delegator: AccountId) -> Vec<PermissionId> {
+    System::events()
+        .into_iter()
+        .filter_map(|record| {
+            if let RuntimeEvent::Permission0(pallet_permission0::Event::PermissionDelegated {
+                delegator: event_delegator,
+                permission_id,
+            }) = record.event
+            {
+                if event_delegator == delegator {
+                    Some(permission_id)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+// Helper to get permission ID where a specific account is the recipient
+// This checks the actual permission scope to find the recipient
+fn get_permission_id_for_recipient(recipient: AccountId) -> PermissionId {
+    // Look through all permissions to find one where this account is the recipient
+    for (permission_id, contract) in Permissions::<Test>::iter() {
+        match &contract.scope {
+            PermissionScope::Curator(scope) if scope.recipient == recipient => {
+                return permission_id;
+            }
+            PermissionScope::Namespace(scope) if scope.recipient == recipient => {
+                return permission_id;
+            }
+            PermissionScope::Emission(scope) if scope.recipients.contains_key(&recipient) => {
+                return permission_id;
+            }
+            _ => continue,
+        }
+    }
+    panic!("No permission found for recipient: {:?}", recipient);
+}
+
 fn register_agent(id: AccountId) {
     let name = match id {
         0 => "alice".to_string(),
@@ -487,10 +557,10 @@ fn delegate_namespace_permission_creates_correct_scope() {
 
         let (_, permission) = permissions.first().unwrap();
         assert_eq!(permission.delegator, delegator);
-        assert_eq!(permission.recipient, recipient);
 
         match &permission.scope {
             PermissionScope::Namespace(namespace_scope) => {
+                assert_eq!(namespace_scope.recipient, recipient);
                 assert_eq!(namespace_scope.paths.len(), 1);
                 let expected_path = NamespacePath::new_agent(b"agent.alice.compute").unwrap();
                 // Check that the path exists in the map under the None key (delegator's own namespace)
@@ -566,7 +636,7 @@ fn delegate_namespace_permission_fails_with_too_many_total_namespaces_across_par
             RevocationTerms::Irrevocable,
             1
         ));
-        let parent_permission_id = PermissionsByDelegator::<Test>::get(delegator)[0];
+        let parent_permission_id = get_last_delegated_permission_id(delegator);
 
         let mut child_namespace_set = BoundedBTreeSet::new();
         for i in 0..6 {
@@ -654,7 +724,7 @@ fn delegate_namespace_permission_fails_when_delegator_not_recipient_of_parent() 
             RevocationTerms::Irrevocable,
             1
         ));
-        let parent_permission_id = PermissionsByDelegator::<Test>::get(original_delegator)[0];
+        let parent_permission_id = get_last_delegated_permission_id(original_delegator);
 
         // Try to use the parent permission from wrong_delegator (who is not the recipient)
         let bounded_gpu = register_namespace(original_delegator, b"agent.alice.compute.gpu");
@@ -690,7 +760,7 @@ fn delegate_namespace_permission_fails_when_parent_has_wrong_scope() {
 
         // Create a curator permission (non-namespace scope)
         delegate_curator_permission(recipient, CuratorPermissions::all(), None);
-        let curator_permission_id = PermissionsByRecipient::<Test>::get(recipient)[0];
+        let curator_permission_id = get_permission_id_for_recipient(recipient);
 
         // Try to use the curator permission as parent for namespace permission
         let bounded_namespace = register_namespace(delegator, b"agent.alice.compute");
@@ -741,7 +811,7 @@ fn delegate_namespace_permission_fails_when_exceeding_available_instances() {
             RevocationTerms::Irrevocable,
             2 // Only 2 instances available
         ));
-        let parent_permission_id = PermissionsByDelegator::<Test>::get(delegator)[0];
+        let parent_permission_id = get_last_delegated_permission_id(delegator);
 
         // Try to create child permission that requires more instances than available
         let bounded_gpu = register_namespace(delegator, b"agent.alice.compute.gpu");
@@ -792,7 +862,7 @@ fn permission_contract_available_instances_reduces_with_children() {
             RevocationTerms::Irrevocable,
             5 // 5 instances total
         ));
-        let parent_permission_id = PermissionsByDelegator::<Test>::get(delegator)[0];
+        let parent_permission_id = get_last_delegated_permission_id(delegator);
 
         // Verify initial available instances
         let parent_permission = Permissions::<Test>::get(parent_permission_id).unwrap();
@@ -851,7 +921,7 @@ fn delegate_granular_namespace_from_parent_permission_succeeds() {
             RevocationTerms::Irrevocable,
             5
         ));
-        let alice_permission_id = PermissionsByDelegator::<Test>::get(alice)[0];
+        let alice_permission_id = get_last_delegated_permission_id(alice);
 
         // Bob (as intermediary) can delegate more granular namespaces that exist
         // This tests the behavior in resolve_paths where it checks:
@@ -874,7 +944,7 @@ fn delegate_granular_namespace_from_parent_permission_succeeds() {
             RevocationTerms::Irrevocable,
             2
         ));
-        let bob_permission_id = PermissionsByDelegator::<Test>::get(bob)[0];
+        let bob_permission_id = get_last_delegated_permission_id(bob);
 
         // Charlie can further delegate even more granular namespaces
         let mut charlie_very_granular_set = BoundedBTreeSet::new();
@@ -929,7 +999,7 @@ fn delegate_granular_namespace_fails_when_granular_namespace_does_not_exist() {
             RevocationTerms::Irrevocable,
             5
         ));
-        let alice_permission_id = PermissionsByDelegator::<Test>::get(alice)[0];
+        let alice_permission_id = get_last_delegated_permission_id(alice);
 
         // Bob tries to delegate granular namespace that doesn't exist
         // This should fail because namespace_exists check returns false
@@ -983,7 +1053,7 @@ fn delegate_namespace_fails_when_child_not_granular_of_parent() {
             RevocationTerms::Irrevocable,
             5
         ));
-        let alice_permission_id = PermissionsByDelegator::<Test>::get(alice)[0];
+        let alice_permission_id = get_last_delegated_permission_id(alice);
 
         // Bob tries to delegate storage namespace using compute parent permission
         // This should fail because storage is not granular of compute
@@ -1037,7 +1107,7 @@ fn delegate_namespace_succeeds_with_exact_match_from_parent() {
             RevocationTerms::Irrevocable,
             5
         ));
-        let alice_permission_id = PermissionsByDelegator::<Test>::get(alice)[0];
+        let alice_permission_id = get_last_delegated_permission_id(alice);
 
         // Bob can delegate the exact same namespace (exact match case in resolve_paths)
         let mut bob_exact_set = BoundedBTreeSet::new();
@@ -1099,7 +1169,7 @@ fn revoke_namespace_permission_cascades_through_multiple_levels() {
             RevocationTerms::RevocableByDelegator, // Alice can revoke
             10                                     // Plenty of instances
         ));
-        let alice_permission_id = PermissionsByDelegator::<Test>::get(alice)[0];
+        let alice_permission_id = get_last_delegated_permission_id(alice);
 
         // Level 2: Bob delegates to Charlie
         let mut bob_paths = BoundedBTreeMap::new();
@@ -1117,7 +1187,7 @@ fn revoke_namespace_permission_cascades_through_multiple_levels() {
             RevocationTerms::RevocableByDelegator, // Bob can revoke
             8
         ));
-        let bob_permission_id = PermissionsByDelegator::<Test>::get(bob)[0];
+        let bob_permission_id = get_last_delegated_permission_id(bob);
 
         // Level 3: Charlie delegates to Dave
         let mut charlie_paths = BoundedBTreeMap::new();
@@ -1135,7 +1205,7 @@ fn revoke_namespace_permission_cascades_through_multiple_levels() {
             RevocationTerms::RevocableByDelegator, // Charlie can revoke
             5
         ));
-        let charlie_permission_id = PermissionsByDelegator::<Test>::get(charlie)[0];
+        let charlie_permission_id = get_last_delegated_permission_id(charlie);
 
         // Level 4: Dave delegates to Eve (final level)
         let mut dave_paths = BoundedBTreeMap::new();
@@ -1153,7 +1223,7 @@ fn revoke_namespace_permission_cascades_through_multiple_levels() {
             RevocationTerms::RevocableByDelegator, // Dave can revoke
             2
         ));
-        let dave_permission_id = PermissionsByDelegator::<Test>::get(dave)[0];
+        let dave_permission_id = get_last_delegated_permission_id(dave);
 
         // Verify the full delegation chain exists
         assert_eq!(PermissionsByDelegator::<Test>::get(alice).len(), 1);
@@ -1268,7 +1338,7 @@ fn revoke_middle_permission_cascades_to_children_only() {
             RevocationTerms::RevocableByDelegator,
             10
         ));
-        let alice_permission_id = PermissionsByDelegator::<Test>::get(alice)[0];
+        let alice_permission_id = get_last_delegated_permission_id(alice);
 
         let mut bob_paths = BoundedBTreeMap::new();
         let mut bob_set = BoundedBTreeSet::new();
@@ -1285,7 +1355,7 @@ fn revoke_middle_permission_cascades_to_children_only() {
             RevocationTerms::RevocableByDelegator,
             7
         ));
-        let bob_permission_id = PermissionsByDelegator::<Test>::get(bob)[0];
+        let bob_permission_id = get_last_delegated_permission_id(bob);
 
         let mut charlie_paths = BoundedBTreeMap::new();
         let mut charlie_set = BoundedBTreeSet::new();
@@ -1302,7 +1372,7 @@ fn revoke_middle_permission_cascades_to_children_only() {
             RevocationTerms::RevocableByDelegator,
             3
         ));
-        let charlie_permission_id = PermissionsByDelegator::<Test>::get(charlie)[0];
+        let charlie_permission_id = get_last_delegated_permission_id(charlie);
 
         // Verify initial state
         assert_eq!(PermissionsByDelegator::<Test>::get(alice).len(), 1);
@@ -1454,7 +1524,7 @@ fn delegate_namespace_permission_requires_weaker_revocation_terms() {
             RevocationTerms::RevocableAfter(200),
             5
         ));
-        let alice_permission_id = PermissionsByDelegator::<Test>::get(alice)[0];
+        let alice_permission_id = get_last_delegated_permission_id(alice);
 
         let bob_paths = paths_map!(Some(alice_permission_id) => [gpu_namespace.clone()]);
 
@@ -1521,7 +1591,7 @@ fn delegate_namespace_permission_irrevocable_parent_allows_revocable_after() {
             RevocationTerms::Irrevocable,
             3
         ));
-        let alice_permission_id = PermissionsByDelegator::<Test>::get(alice)[0];
+        let alice_permission_id = get_last_delegated_permission_id(alice);
 
         let bob_paths = paths_map!(Some(alice_permission_id) => [register_namespace(alice, b"agent.alice.compute.gpu")]);
         assert_ok!(Permission0::delegate_namespace_permission(
@@ -1572,7 +1642,7 @@ fn delegate_namespace_permission_fails_when_exceeding_depth_limit() {
                 10
             ));
 
-            parent_permission_id = Some(PermissionsByDelegator::<Test>::get(delegator)[0]);
+            parent_permission_id = Some(get_last_delegated_permission_id(delegator));
         }
 
         for to_fail in [level5, level6] {
@@ -1619,7 +1689,7 @@ fn update_namespace_permission_basic_validations() {
             RevocationTerms::Irrevocable,
             5
         ));
-        let permission_id = PermissionsByDelegator::<Test>::get(delegator)[0];
+        let permission_id = get_last_delegated_permission_id(delegator);
 
         assert_err!(
             Permission0::update_namespace_permission(get_origin(not_delegator), permission_id, 10),
@@ -1659,7 +1729,7 @@ fn update_namespace_permission_larger_instances() {
             RevocationTerms::Irrevocable,
             5
         ));
-        let no_parent_permission_id = PermissionsByDelegator::<Test>::get(delegator)[0];
+        let no_parent_permission_id = get_last_delegated_permission_id(delegator);
 
         // can increase without limit when no parent
         assert_ok!(Permission0::update_namespace_permission(
@@ -1681,7 +1751,7 @@ fn update_namespace_permission_larger_instances() {
             RevocationTerms::Irrevocable,
             20
         ));
-        let parent_permission_id = PermissionsByDelegator::<Test>::get(delegator)[1];
+        let parent_permission_id = get_all_delegated_permission_ids(delegator)[1];
 
         let child_paths = paths_map!(Some(parent_permission_id) => [register_namespace(delegator, b"agent.alice.storage.ssd")]);
 
@@ -1693,7 +1763,7 @@ fn update_namespace_permission_larger_instances() {
             RevocationTerms::Irrevocable,
             5
         ));
-        let child_permission_id = PermissionsByDelegator::<Test>::get(recipient_2)[0];
+        let child_permission_id = get_last_delegated_permission_id(recipient_2);
 
         let parent = Permissions::<Test>::get(parent_permission_id).unwrap();
         assert_eq!(parent.available_instances(), 15);
@@ -1744,7 +1814,7 @@ fn update_namespace_permission_smaller_instances() {
             RevocationTerms::RevocableAfter(revocable_after_block),
             10
         ));
-        let parent_permission_id = PermissionsByDelegator::<Test>::get(delegator)[0];
+        let parent_permission_id = get_last_delegated_permission_id(delegator);
 
         let child_paths = paths_map!(Some(parent_permission_id) => [register_namespace(delegator, b"agent.alice.compute.gpu")]);
         assert_ok!(Permission0::delegate_namespace_permission(
@@ -1800,7 +1870,7 @@ fn update_namespace_permission_smaller_instances() {
             RevocationTerms::Irrevocable,
             20
         ));
-        let irrevocable_permission_id = PermissionsByDelegator::<Test>::get(delegator)[1];
+        let irrevocable_permission_id = get_all_delegated_permission_ids(delegator)[1];
 
         // cannot reduce irrevocable permission
         assert_err!(
@@ -1821,7 +1891,7 @@ fn update_namespace_permission_smaller_instances() {
             RevocationTerms::RevocableByDelegator,
             15
         ));
-        let revocable_permission_id = PermissionsByDelegator::<Test>::get(delegator)[2];
+        let revocable_permission_id = get_all_delegated_permission_ids(delegator)[2];
 
         assert_ok!(Permission0::update_namespace_permission(
             get_origin(delegator),

--- a/pallets/permission0/tests/stream.rs
+++ b/pallets/permission0/tests/stream.rs
@@ -39,7 +39,7 @@ fn get_last_delegated_permission_id(delegator: AccountId) -> pallet_permission0:
                 None
             }
         })
-        .last() // Get most recent
+        .next_back() // Get most recent
         .expect("No PermissionDelegated event found")
 }
 
@@ -724,11 +724,11 @@ fn recipient_revocation_removes_single_recipient_from_multiple() {
         assert!(scope.recipients.contains_key(&agent_2));
 
         assert!(
-            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_1)
+            pallet_permission0::PermissionsByRecipient::<Test>::get(agent_1)
                 .contains(&permission_id)
         );
         assert!(
-            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_2)
+            pallet_permission0::PermissionsByRecipient::<Test>::get(agent_2)
                 .contains(&permission_id)
         );
 
@@ -747,11 +747,11 @@ fn recipient_revocation_removes_single_recipient_from_multiple() {
 
         // Verify indices updated correctly
         assert!(
-            !pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_1)
+            !pallet_permission0::PermissionsByRecipient::<Test>::get(agent_1)
                 .contains(&permission_id)
         );
         assert!(
-            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_2)
+            pallet_permission0::PermissionsByRecipient::<Test>::get(agent_2)
                 .contains(&permission_id)
         );
 
@@ -766,7 +766,7 @@ fn recipient_revocation_removes_single_recipient_from_multiple() {
             permission_id
         ));
         assert!(
-            !pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_2)
+            !pallet_permission0::PermissionsByRecipient::<Test>::get(agent_2)
                 .contains(&permission_id)
         );
     });
@@ -802,7 +802,7 @@ fn recipient_revocation_deletes_permission_when_single_recipient() {
             permission_id
         ));
         assert!(
-            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_1)
+            pallet_permission0::PermissionsByRecipient::<Test>::get(agent_1)
                 .contains(&permission_id)
         );
 
@@ -817,7 +817,7 @@ fn recipient_revocation_deletes_permission_when_single_recipient() {
             permission_id
         ));
         assert!(
-            !pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_1)
+            !pallet_permission0::PermissionsByRecipient::<Test>::get(agent_1)
                 .contains(&permission_id)
         );
     });
@@ -1013,7 +1013,7 @@ fn recipient_manager_can_modify_keys_and_weights() {
         };
         assert_eq!(scope.recipients, new_recipients);
         assert!(
-            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_2)
+            pallet_permission0::PermissionsByRecipient::<Test>::get(agent_2)
                 .contains(&permission_id)
         );
 
@@ -1040,11 +1040,11 @@ fn recipient_manager_can_modify_keys_and_weights() {
         };
         assert_eq!(scope.recipients, reduced_recipients);
         assert!(
-            !pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_1)
+            !pallet_permission0::PermissionsByRecipient::<Test>::get(agent_1)
                 .contains(&permission_id)
         );
         assert!(
-            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_2)
+            pallet_permission0::PermissionsByRecipient::<Test>::get(agent_2)
                 .contains(&permission_id)
         );
 
@@ -1207,8 +1207,8 @@ fn delegator_can_assign_and_remove_managers() {
         let pallet_permission0::PermissionScope::Emission(scope) = permission.scope else {
             panic!("Expected emission scope");
         };
-        assert_eq!(scope.weight_setter, Some(weight_setter));
-        assert_eq!(scope.recipient_manager, Some(recipient_manager));
+        assert!(scope.weight_setters.contains(&weight_setter));
+        assert!(scope.recipient_managers.contains(&recipient_manager));
 
         // Now managers can operate within their permissions
         let mut new_recipients = BoundedBTreeMap::new();
@@ -1244,8 +1244,8 @@ fn delegator_can_assign_and_remove_managers() {
         let pallet_permission0::PermissionScope::Emission(scope) = permission.scope else {
             panic!("Expected emission scope");
         };
-        assert_eq!(scope.weight_setter, None);
-        assert_eq!(scope.recipient_manager, None);
+        assert!(scope.weight_setters.len() == 1 && scope.weight_setters.contains(&agent_0));
+        assert!(scope.recipient_managers.len() == 1 && scope.recipient_managers.contains(&agent_0));
 
         // Former managers should no longer have access
         assert_err!(
@@ -1311,19 +1311,19 @@ fn index_consistency_during_complex_recipient_updates() {
 
         // Verify initial indices
         assert!(
-            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_1)
+            pallet_permission0::PermissionsByRecipient::<Test>::get(agent_1)
                 .contains(&permission_id)
         );
         assert!(
-            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_2)
+            pallet_permission0::PermissionsByRecipient::<Test>::get(agent_2)
                 .contains(&permission_id)
         );
         assert!(
-            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_3)
+            pallet_permission0::PermissionsByRecipient::<Test>::get(agent_3)
                 .contains(&permission_id)
         );
         assert!(
-            !pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_4)
+            !pallet_permission0::PermissionsByRecipient::<Test>::get(agent_4)
                 .contains(&permission_id)
         );
 
@@ -1360,25 +1360,25 @@ fn index_consistency_during_complex_recipient_updates() {
 
         // Verify ALL indices are consistent
         assert!(
-            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_1)
+            pallet_permission0::PermissionsByRecipient::<Test>::get(agent_1)
                 .contains(&permission_id)
         ); // Still there
         assert!(
-            !pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_2)
+            !pallet_permission0::PermissionsByRecipient::<Test>::get(agent_2)
                 .contains(&permission_id)
         ); // Removed
         assert!(
-            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_3)
+            pallet_permission0::PermissionsByRecipient::<Test>::get(agent_3)
                 .contains(&permission_id)
         ); // Still there
         assert!(
-            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_4)
+            pallet_permission0::PermissionsByRecipient::<Test>::get(agent_4)
                 .contains(&permission_id)
         ); // Added
 
         // Verify delegator indices are also consistent
         let delegator_permissions =
-            pallet_permission0::PermissionsByDelegator::<Test>::get(&agent_0);
+            pallet_permission0::PermissionsByDelegator::<Test>::get(agent_0);
         assert!(delegator_permissions.contains(&permission_id));
 
         // Verify participants indices include all current participants

--- a/pallets/permission0/tests/stream.rs
+++ b/pallets/permission0/tests/stream.rs
@@ -16,6 +16,33 @@ use test_utils::{
     *,
 };
 
+pub fn new_test_ext() -> polkadot_sdk::sp_io::TestExternalities {
+    new_test_ext_with_block(1)
+}
+
+// Helper to get the most recent permission ID from events
+fn get_last_delegated_permission_id(delegator: AccountId) -> pallet_permission0::PermissionId {
+    System::events()
+        .into_iter()
+        .filter_map(|record| {
+            if let RuntimeEvent::Permission0(pallet_permission0::Event::PermissionDelegated {
+                delegator: event_delegator,
+                permission_id,
+            }) = record.event
+            {
+                if event_delegator == delegator {
+                    Some(permission_id)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .last() // Get most recent
+        .expect("No PermissionDelegated event found")
+}
+
 #[test]
 fn stream_fails_if_overflow() {
     new_test_ext().execute_with(|| {
@@ -35,9 +62,8 @@ fn stream_fails_if_overflow() {
 
         assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
+            vec![(agent_1, u16::MAX)],
             pallet_permission0_api::EmissionAllocation::Streams(streams),
-            vec![(agent_0, u16::MAX)],
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -52,9 +78,8 @@ fn stream_fails_if_overflow() {
         assert_err!(
             delegate_emission_permission(
                 agent_0,
-                agent_1,
+                vec![(agent_1, u16::MAX)],
                 pallet_permission0_api::EmissionAllocation::Streams(streams),
-                vec![(agent_0, u16::MAX)],
                 pallet_permission0_api::DistributionControl::Manual,
                 pallet_permission0_api::PermissionDuration::Indefinite,
                 pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -84,9 +109,8 @@ fn stream_creates() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
+            vec![(agent_1, u16::MAX)],
             pallet_permission0_api::EmissionAllocation::Streams(streams),
-            vec![(agent_0, u16::MAX)],
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -131,9 +155,8 @@ fn stream_manual_executes() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
-            pallet_permission0_api::EmissionAllocation::Streams(streams),
             vec![(agent_1, u16::MAX)],
+            pallet_permission0_api::EmissionAllocation::Streams(streams),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -156,7 +179,7 @@ fn stream_manual_executes() {
 
 #[test]
 fn stream_accumulates_and_executes_at_threshold() {
-    test_utils::new_test_ext().execute_with(|| {
+    test_utils::new_test_ext_with_block(100).execute_with(|| {
         let ratio = 10;
         let (min_validator_stake, _) = set_emissions_params();
 
@@ -188,9 +211,8 @@ fn stream_accumulates_and_executes_at_threshold() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             miner,
-            miner,
-            pallet_permission0_api::EmissionAllocation::Streams(streams),
             vec![(val, u16::MAX)],
+            pallet_permission0_api::EmissionAllocation::Streams(streams),
             pallet_permission0_api::DistributionControl::Automatic(total_incentives),
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -237,7 +259,7 @@ fn set_emissions_params() -> (u128, Percent) {
 
 #[test]
 fn random_cannot_change_permission() {
-    test_utils::new_test_ext().execute_with(|| {
+    new_test_ext().execute_with(|| {
         zero_min_burn();
         let agent_0 = 0;
         register_empty_agent(agent_0);
@@ -257,9 +279,8 @@ fn random_cannot_change_permission() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
+            vec![(agent_1, u16::MAX)],
             pallet_permission0_api::EmissionAllocation::Streams(streams),
-            vec![(agent_0, u16::MAX)],
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -280,7 +301,9 @@ fn random_cannot_change_permission() {
             pallet_permission0::Pallet::<Test>::update_emission_permission(
                 get_origin(agent_2),
                 permission_id,
-                BoundedBTreeMap::new(),
+                Some(BoundedBTreeMap::new()),
+                None,
+                None,
                 None,
                 None
             ),
@@ -291,7 +314,7 @@ fn random_cannot_change_permission() {
 
 #[test]
 fn delegator_cannot_change_irrevocable_permission() {
-    test_utils::new_test_ext().execute_with(|| {
+    new_test_ext().execute_with(|| {
         zero_min_burn();
         let agent_0 = 0;
         register_empty_agent(agent_0);
@@ -308,9 +331,8 @@ fn delegator_cannot_change_irrevocable_permission() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
+            vec![(agent_1, u16::MAX)],
             pallet_permission0_api::EmissionAllocation::Streams(streams),
-            vec![(agent_0, u16::MAX)],
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::Irrevocable,
@@ -327,14 +349,16 @@ fn delegator_cannot_change_irrevocable_permission() {
             &permission_id
         )));
 
-        let mut new_targets = BoundedBTreeMap::new();
-        new_targets.try_insert(agent_0, u16::MAX).unwrap();
+        let mut new_recipients = BoundedBTreeMap::new();
+        new_recipients.try_insert(agent_1, u16::MAX).unwrap();
 
         assert_err!(
             pallet_permission0::Pallet::<Test>::update_emission_permission(
                 get_origin(agent_0),
                 permission_id,
-                new_targets,
+                Some(new_recipients),
+                None,
+                None,
                 None,
                 None
             ),
@@ -345,7 +369,7 @@ fn delegator_cannot_change_irrevocable_permission() {
 
 #[test]
 fn delegator_cannot_change_arbiter_permission() {
-    test_utils::new_test_ext().execute_with(|| {
+    new_test_ext().execute_with(|| {
         zero_min_burn();
         let agent_0 = 0;
         register_empty_agent(agent_0);
@@ -353,10 +377,10 @@ fn delegator_cannot_change_arbiter_permission() {
         let agent_1 = 1;
         register_empty_agent(agent_1);
 
-        let agent_2 = 1;
+        let agent_2 = 2;
         register_empty_agent(agent_2);
 
-        let agent_3 = 1;
+        let agent_3 = 3;
         register_empty_agent(agent_3);
 
         add_balance(agent_0, as_tors(10) + 1);
@@ -368,9 +392,8 @@ fn delegator_cannot_change_arbiter_permission() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
+            vec![(agent_1, u16::MAX)],
             pallet_permission0_api::EmissionAllocation::Streams(streams),
-            vec![(agent_0, u16::MAX)],
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::RevocableByArbiters {
@@ -390,14 +413,16 @@ fn delegator_cannot_change_arbiter_permission() {
             &permission_id
         )));
 
-        let mut new_targets = BoundedBTreeMap::new();
-        new_targets.try_insert(agent_0, u16::MAX).unwrap();
+        let mut new_recipients = BoundedBTreeMap::new();
+        new_recipients.try_insert(agent_1, u16::MAX).unwrap();
 
         assert_err!(
             pallet_permission0::Pallet::<Test>::update_emission_permission(
                 get_origin(agent_0),
                 permission_id,
-                new_targets,
+                Some(new_recipients),
+                None,
+                None,
                 None,
                 None
             ),
@@ -408,7 +433,7 @@ fn delegator_cannot_change_arbiter_permission() {
 
 #[test]
 fn delegator_cannot_change_permission_before_block() {
-    test_utils::new_test_ext().execute_with(|| {
+    new_test_ext().execute_with(|| {
         zero_min_burn();
         let agent_0 = 0;
         register_empty_agent(agent_0);
@@ -416,10 +441,10 @@ fn delegator_cannot_change_permission_before_block() {
         let agent_1 = 1;
         register_empty_agent(agent_1);
 
-        let agent_2 = 1;
+        let agent_2 = 2;
         register_empty_agent(agent_2);
 
-        let agent_3 = 1;
+        let agent_3 = 3;
         register_empty_agent(agent_3);
 
         add_balance(agent_0, as_tors(10) + 1);
@@ -431,9 +456,8 @@ fn delegator_cannot_change_permission_before_block() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
+            vec![(agent_1, u16::MAX)],
             pallet_permission0_api::EmissionAllocation::Streams(streams),
-            vec![(agent_0, u16::MAX)],
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::RevocableAfter(5),
@@ -450,14 +474,16 @@ fn delegator_cannot_change_permission_before_block() {
             &permission_id
         )));
 
-        let mut new_targets = BoundedBTreeMap::new();
-        new_targets.try_insert(agent_0, u16::MAX).unwrap();
+        let mut new_recipients = BoundedBTreeMap::new();
+        new_recipients.try_insert(agent_2, u16::MAX).unwrap();
 
         assert_err!(
             pallet_permission0::Pallet::<Test>::update_emission_permission(
                 get_origin(agent_0),
                 permission_id,
-                new_targets,
+                Some(new_recipients),
+                None,
+                None,
                 None,
                 None
             ),
@@ -466,14 +492,16 @@ fn delegator_cannot_change_permission_before_block() {
 
         step_block(6);
 
-        let mut new_targets = BoundedBTreeMap::new();
-        new_targets.try_insert(agent_0, u16::MAX).unwrap();
+        let mut new_recipients = BoundedBTreeMap::new();
+        new_recipients.try_insert(agent_2, u16::MAX).unwrap();
 
         assert_ok!(
             pallet_permission0::Pallet::<Test>::update_emission_permission(
                 get_origin(agent_0),
                 permission_id,
-                new_targets,
+                Some(new_recipients),
+                None,
+                None,
                 None,
                 None
             )
@@ -482,8 +510,8 @@ fn delegator_cannot_change_permission_before_block() {
 }
 
 #[test]
-fn recipient_can_only_change_targets() {
-    test_utils::new_test_ext().execute_with(|| {
+fn recipient_can_only_change_recipients() {
+    new_test_ext().execute_with(|| {
         zero_min_burn();
         let agent_0 = 0;
         register_empty_agent(agent_0);
@@ -491,10 +519,10 @@ fn recipient_can_only_change_targets() {
         let agent_1 = 1;
         register_empty_agent(agent_1);
 
-        let agent_2 = 1;
+        let agent_2 = 2;
         register_empty_agent(agent_2);
 
-        let agent_3 = 1;
+        let agent_3 = 3;
         register_empty_agent(agent_3);
 
         add_balance(agent_0, as_tors(10) + 1);
@@ -506,9 +534,8 @@ fn recipient_can_only_change_targets() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
+            vec![(agent_1, u16::MAX)],
             pallet_permission0_api::EmissionAllocation::Streams(streams),
-            vec![(agent_0, u16::MAX)],
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::RevocableAfter(5),
@@ -525,15 +552,17 @@ fn recipient_can_only_change_targets() {
             &permission_id
         )));
 
-        let mut new_targets = BoundedBTreeMap::new();
-        new_targets.try_insert(agent_0, u16::MAX).unwrap();
+        let mut new_recipients = BoundedBTreeMap::new();
+        new_recipients.try_insert(agent_2, u16::MAX).unwrap();
 
         assert_err!(
             pallet_permission0::Pallet::<Test>::update_emission_permission(
                 get_origin(agent_1),
                 permission_id,
-                new_targets,
+                Some(new_recipients),
                 Some(BoundedBTreeMap::new()),
+                None,
+                None,
                 None
             ),
             pallet_permission0::Error::<Test>::NotAuthorizedToEdit
@@ -541,16 +570,18 @@ fn recipient_can_only_change_targets() {
 
         step_block(6);
 
-        let mut new_targets = BoundedBTreeMap::new();
-        new_targets.try_insert(agent_0, u16::MAX).unwrap();
+        let mut new_recipients = BoundedBTreeMap::new();
+        new_recipients.try_insert(agent_2, u16::MAX).unwrap();
 
         assert_err!(
             pallet_permission0::Pallet::<Test>::update_emission_permission(
                 get_origin(agent_1),
                 permission_id,
-                new_targets,
+                Some(new_recipients),
                 None,
-                Some(pallet_permission0::DistributionControl::Manual)
+                Some(pallet_permission0::DistributionControl::Manual),
+                None,
+                None
             ),
             pallet_permission0::Error::<Test>::NotAuthorizedToEdit
         );
@@ -559,7 +590,7 @@ fn recipient_can_only_change_targets() {
 
 #[test]
 fn updating_works() {
-    test_utils::new_test_ext().execute_with(|| {
+    new_test_ext().execute_with(|| {
         zero_min_burn();
         let agent_0 = 0;
         register_empty_agent(agent_0);
@@ -567,10 +598,10 @@ fn updating_works() {
         let agent_1 = 1;
         register_empty_agent(agent_1);
 
-        let agent_2 = 1;
+        let agent_2 = 2;
         register_empty_agent(agent_2);
 
-        let agent_3 = 1;
+        let agent_3 = 3;
         register_empty_agent(agent_3);
 
         add_balance(agent_0, as_tors(10) + 1);
@@ -581,9 +612,8 @@ fn updating_works() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_1,
+            vec![(agent_1, u16::MAX)],
             pallet_permission0_api::EmissionAllocation::Streams(streams.clone()),
-            vec![(agent_0, u16::MAX)],
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
             pallet_permission0_api::RevocationTerms::RevocableByDelegator,
@@ -600,8 +630,8 @@ fn updating_works() {
             &permission_id
         )));
 
-        let mut new_targets = BoundedBTreeMap::new();
-        new_targets.try_insert(agent_1, u16::MAX).unwrap();
+        let mut new_recipients = BoundedBTreeMap::new();
+        new_recipients.try_insert(agent_1, u16::MAX).unwrap();
 
         let new_stream = generate_root_stream_id(&agent_1);
         let mut new_streams = BTreeMap::new();
@@ -611,9 +641,11 @@ fn updating_works() {
             pallet_permission0::Pallet::<Test>::update_emission_permission(
                 get_origin(agent_0),
                 permission_id,
-                new_targets.clone(),
+                Some(new_recipients.clone()),
                 Some(new_streams.clone().try_into().unwrap()),
-                Some(pallet_permission0::DistributionControl::Interval(100))
+                Some(pallet_permission0::DistributionControl::Interval(100)),
+                None,
+                None
             )
         );
 
@@ -647,13 +679,13 @@ fn updating_works() {
             pallet_permission0::DistributionControl::Interval(100)
         );
 
-        assert_eq!(emission_scope.targets, new_targets);
+        assert_eq!(emission_scope.recipients, new_recipients);
     });
 }
 
 #[test]
-fn update_prevents_overarching_update_when_delegator_is_recipient() {
-    test_utils::new_test_ext().execute_with(|| {
+fn recipient_revocation_removes_single_recipient_from_multiple() {
+    new_test_ext().execute_with(|| {
         zero_min_burn();
         let agent_0 = 0;
         register_empty_agent(agent_0);
@@ -661,10 +693,10 @@ fn update_prevents_overarching_update_when_delegator_is_recipient() {
         let agent_1 = 1;
         register_empty_agent(agent_1);
 
-        let agent_2 = 1;
+        let agent_2 = 2;
         register_empty_agent(agent_2);
 
-        let agent_3 = 1;
+        let agent_3 = 3;
         register_empty_agent(agent_3);
 
         add_balance(agent_0, as_tors(10) + 1);
@@ -675,49 +707,710 @@ fn update_prevents_overarching_update_when_delegator_is_recipient() {
 
         let permission_id = assert_ok!(delegate_emission_permission(
             agent_0,
-            agent_0,
-            pallet_permission0_api::EmissionAllocation::Streams(streams.clone()),
-            vec![(agent_1, u16::MAX)],
+            vec![(agent_1, u16::MAX / 2), (agent_2, u16::MAX / 2)],
+            pallet_permission0_api::EmissionAllocation::Streams(streams),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
-            pallet_permission0_api::RevocationTerms::RevocableAfter(5),
+            pallet_permission0_api::RevocationTerms::Irrevocable,
             pallet_permission0_api::EnforcementAuthority::None,
         ));
 
-        let mut new_targets = BoundedBTreeMap::new();
-        new_targets.try_insert(agent_1, u16::MAX).unwrap();
+        let permission = pallet_permission0::Permissions::<Test>::get(permission_id).unwrap();
+        let pallet_permission0::PermissionScope::Emission(scope) = permission.scope else {
+            panic!("Expected emission scope");
+        };
+        assert_eq!(scope.recipients.len(), 2);
+        assert!(scope.recipients.contains_key(&agent_1));
+        assert!(scope.recipients.contains_key(&agent_2));
 
-        assert_err!(
-            pallet_permission0::Pallet::<Test>::update_emission_permission(
-                get_origin(agent_0),
-                permission_id,
-                new_targets.clone(),
-                Some(BoundedBTreeMap::new()),
-                None
-            ),
-            pallet_permission0::Error::<Test>::NotAuthorizedToEdit
+        assert!(
+            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_1)
+                .contains(&permission_id)
         );
+        assert!(
+            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_2)
+                .contains(&permission_id)
+        );
+
+        assert_ok!(pallet_permission0::Pallet::<Test>::revoke_permission(
+            get_origin(agent_1),
+            permission_id
+        ));
+
+        let permission = pallet_permission0::Permissions::<Test>::get(permission_id).unwrap();
+        let pallet_permission0::PermissionScope::Emission(scope) = permission.scope else {
+            panic!("Expected emission scope");
+        };
+        assert_eq!(scope.recipients.len(), 1);
+        assert!(!scope.recipients.contains_key(&agent_1));
+        assert!(scope.recipients.contains_key(&agent_2));
+
+        // Verify indices updated correctly
+        assert!(
+            !pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_1)
+                .contains(&permission_id)
+        );
+        assert!(
+            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_2)
+                .contains(&permission_id)
+        );
+
+        // Agent_2 revokes their part (should delete entire permission)
+        assert_ok!(pallet_permission0::Pallet::<Test>::revoke_permission(
+            get_origin(agent_2),
+            permission_id
+        ));
+
+        // Permission should be completely deleted
+        assert!(!pallet_permission0::Permissions::<Test>::contains_key(
+            permission_id
+        ));
+        assert!(
+            !pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_2)
+                .contains(&permission_id)
+        );
+    });
+}
+
+#[test]
+fn recipient_revocation_deletes_permission_when_single_recipient() {
+    new_test_ext().execute_with(|| {
+        zero_min_burn();
+        let agent_0 = 0;
+        register_empty_agent(agent_0);
+
+        let agent_1 = 1;
+        register_empty_agent(agent_1);
+
+        add_balance(agent_0, as_tors(10) + 1);
+
+        let stream_id = generate_root_stream_id(&agent_0);
+        let mut streams = BTreeMap::new();
+        streams.insert(stream_id, Percent::from_percent(100));
+
+        let permission_id = assert_ok!(delegate_emission_permission(
+            agent_0,
+            vec![(agent_1, u16::MAX)],
+            pallet_permission0_api::EmissionAllocation::Streams(streams),
+            pallet_permission0_api::DistributionControl::Manual,
+            pallet_permission0_api::PermissionDuration::Indefinite,
+            pallet_permission0_api::RevocationTerms::Irrevocable,
+            pallet_permission0_api::EnforcementAuthority::None,
+        ));
+
+        assert!(pallet_permission0::Permissions::<Test>::contains_key(
+            permission_id
+        ));
+        assert!(
+            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_1)
+                .contains(&permission_id)
+        );
+
+        // Agent_1 revokes (should delete entire permission since it's the only recipient)
+        assert_ok!(pallet_permission0::Pallet::<Test>::revoke_permission(
+            get_origin(agent_1),
+            permission_id
+        ));
+
+        // Permission should be completely deleted
+        assert!(!pallet_permission0::Permissions::<Test>::contains_key(
+            permission_id
+        ));
+        assert!(
+            !pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_1)
+                .contains(&permission_id)
+        );
+    });
+}
+
+#[test]
+fn weight_setter_can_only_modify_weights_not_keys() {
+    new_test_ext().execute_with(|| {
+        zero_min_burn();
+        let agent_0 = 0;
+        register_empty_agent(agent_0);
+
+        let agent_1 = 1;
+        register_empty_agent(agent_1);
+
+        let agent_2 = 2;
+        register_empty_agent(agent_2);
+
+        let weight_setter = 3;
+        register_empty_agent(weight_setter);
+
+        add_balance(agent_0, as_tors(10) + 1);
+
+        let stream_id = generate_root_stream_id(&agent_0);
+        let mut streams = BTreeMap::new();
+        streams.insert(stream_id, Percent::from_percent(100));
+
+        let mut recipients = BoundedBTreeMap::new();
+        recipients.try_insert(agent_1, u16::MAX / 2).unwrap();
+        recipients.try_insert(agent_2, u16::MAX / 2).unwrap();
+
+        assert_ok!(
+            pallet_permission0::Pallet::<Test>::delegate_emission_permission(
+                get_origin(agent_0),
+                recipients,
+                pallet_permission0::EmissionAllocation::Streams(streams.try_into().unwrap()),
+                pallet_permission0::DistributionControl::Manual,
+                pallet_permission0::PermissionDuration::Indefinite,
+                pallet_permission0::RevocationTerms::RevocableByDelegator,
+                pallet_permission0::EnforcementAuthority::None,
+                None,                // recipient_manager
+                Some(weight_setter), // weight_setter
+            )
+        );
+
+        let permission_id = get_last_delegated_permission_id(agent_0);
+
+        // Weight setter can modify weights of existing recipients
+        let mut updated_recipients = BoundedBTreeMap::new();
+        updated_recipients
+            .try_insert(agent_1, u16::MAX / 4)
+            .unwrap();
+        updated_recipients
+            .try_insert(agent_2, (u16::MAX / 4) * 3)
+            .unwrap();
 
         assert_ok!(
             pallet_permission0::Pallet::<Test>::update_emission_permission(
-                get_origin(agent_0),
+                get_origin(weight_setter),
                 permission_id,
-                new_targets.clone(),
+                Some(updated_recipients),
+                None,
+                None,
                 None,
                 None
             )
         );
 
+        // Verify weights were updated
+        let permission = pallet_permission0::Permissions::<Test>::get(permission_id).unwrap();
+        let pallet_permission0::PermissionScope::Emission(scope) = permission.scope else {
+            panic!("Expected emission scope");
+        };
+        assert_eq!(*scope.recipients.get(&agent_1).unwrap(), u16::MAX / 4);
+        assert_eq!(*scope.recipients.get(&agent_2).unwrap(), (u16::MAX / 4) * 3);
+
+        // Weight setter CANNOT add new recipients (changing keys)
+        let agent_3 = 4;
+        register_empty_agent(agent_3);
+        let mut new_recipients = BoundedBTreeMap::new();
+        new_recipients.try_insert(agent_1, u16::MAX / 3).unwrap();
+        new_recipients.try_insert(agent_3, u16::MAX / 3).unwrap(); // New key
+
+        assert_err!(
+            pallet_permission0::Pallet::<Test>::update_emission_permission(
+                get_origin(weight_setter),
+                permission_id,
+                Some(new_recipients),
+                None,
+                None,
+                None,
+                None
+            ),
+            pallet_permission0::Error::<Test>::NotAuthorizedToEdit
+        );
+
+        // Weight setter CANNOT remove recipients (changing keys)
+        let mut reduced_recipients = BoundedBTreeMap::new();
+        reduced_recipients.try_insert(agent_1, u16::MAX).unwrap();
+        // Missing agent_2
+
+        assert_err!(
+            pallet_permission0::Pallet::<Test>::update_emission_permission(
+                get_origin(weight_setter),
+                permission_id,
+                Some(reduced_recipients),
+                None,
+                None,
+                None,
+                None
+            ),
+            pallet_permission0::Error::<Test>::NotAuthorizedToEdit
+        );
+
+        // Weight setter CANNOT modify other parameters
+        assert_err!(
+            pallet_permission0::Pallet::<Test>::update_emission_permission(
+                get_origin(weight_setter),
+                permission_id,
+                None,
+                Some(BoundedBTreeMap::new()),
+                None,
+                None,
+                None
+            ),
+            pallet_permission0::Error::<Test>::NotAuthorizedToEdit
+        );
+    });
+}
+
+#[test]
+fn recipient_manager_can_modify_keys_and_weights() {
+    new_test_ext().execute_with(|| {
+        zero_min_burn();
+        let agent_0 = 0;
+        register_empty_agent(agent_0);
+
+        let agent_1 = 1;
+        register_empty_agent(agent_1);
+
+        let agent_2 = 2;
+        register_empty_agent(agent_2);
+
+        let recipient_manager = 3;
+        register_empty_agent(recipient_manager);
+
+        add_balance(agent_0, as_tors(10) + 1);
+
+        let stream_id = generate_root_stream_id(&agent_0);
+        let mut streams = BTreeMap::new();
+        streams.insert(stream_id, Percent::from_percent(100));
+
+        let mut recipients = BoundedBTreeMap::new();
+        recipients.try_insert(agent_1, u16::MAX).unwrap();
+
+        assert_ok!(
+            pallet_permission0::Pallet::<Test>::delegate_emission_permission(
+                get_origin(agent_0),
+                recipients,
+                pallet_permission0::EmissionAllocation::Streams(streams.try_into().unwrap()),
+                pallet_permission0::DistributionControl::Manual,
+                pallet_permission0::PermissionDuration::Indefinite,
+                pallet_permission0::RevocationTerms::RevocableByDelegator,
+                pallet_permission0::EnforcementAuthority::None,
+                Some(recipient_manager), // recipient_manager
+                None,                    // weight_setter
+            )
+        );
+
+        let permission_id = get_last_delegated_permission_id(agent_0);
+
+        // Recipient manager can add new recipients
+        let mut new_recipients = BoundedBTreeMap::new();
+        new_recipients.try_insert(agent_1, u16::MAX / 2).unwrap();
+        new_recipients.try_insert(agent_2, u16::MAX / 2).unwrap();
+
+        assert_ok!(
+            pallet_permission0::Pallet::<Test>::update_emission_permission(
+                get_origin(recipient_manager),
+                permission_id,
+                Some(new_recipients.clone()),
+                None,
+                None,
+                None,
+                None
+            )
+        );
+
+        // Verify recipients were updated and indices are consistent
+        let permission = pallet_permission0::Permissions::<Test>::get(permission_id).unwrap();
+        let pallet_permission0::PermissionScope::Emission(scope) = permission.scope else {
+            panic!("Expected emission scope");
+        };
+        assert_eq!(scope.recipients, new_recipients);
+        assert!(
+            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_2)
+                .contains(&permission_id)
+        );
+
+        // Recipient manager can remove recipients
+        let mut reduced_recipients = BoundedBTreeMap::new();
+        reduced_recipients.try_insert(agent_2, u16::MAX).unwrap();
+
+        assert_ok!(
+            pallet_permission0::Pallet::<Test>::update_emission_permission(
+                get_origin(recipient_manager),
+                permission_id,
+                Some(reduced_recipients.clone()),
+                None,
+                None,
+                None,
+                None
+            )
+        );
+
+        // Verify recipient was removed and indices updated
+        let permission = pallet_permission0::Permissions::<Test>::get(permission_id).unwrap();
+        let pallet_permission0::PermissionScope::Emission(scope) = permission.scope else {
+            panic!("Expected emission scope");
+        };
+        assert_eq!(scope.recipients, reduced_recipients);
+        assert!(
+            !pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_1)
+                .contains(&permission_id)
+        );
+        assert!(
+            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_2)
+                .contains(&permission_id)
+        );
+
+        // Recipient manager CANNOT modify other parameters
+        assert_err!(
+            pallet_permission0::Pallet::<Test>::update_emission_permission(
+                get_origin(recipient_manager),
+                permission_id,
+                None,
+                Some(BoundedBTreeMap::new()),
+                None,
+                None,
+                None
+            ),
+            pallet_permission0::Error::<Test>::NotAuthorizedToEdit
+        );
+    });
+}
+
+#[test]
+fn manager_modifications_only_allowed_after_revocable_period() {
+    new_test_ext().execute_with(|| {
+        zero_min_burn();
+        let agent_0 = 0;
+        register_empty_agent(agent_0);
+
+        let agent_1 = 1;
+        register_empty_agent(agent_1);
+
+        let agent_2 = 2;
+        register_empty_agent(agent_2);
+
+        let recipient_manager = 3;
+        register_empty_agent(recipient_manager);
+
+        add_balance(agent_0, as_tors(10) + 1);
+
+        let stream_id = generate_root_stream_id(&agent_0);
+        let mut streams = BTreeMap::new();
+        streams.insert(stream_id, Percent::from_percent(100));
+
+        let mut recipients = BoundedBTreeMap::new();
+        recipients.try_insert(agent_1, u16::MAX).unwrap();
+
+        assert_ok!(
+            pallet_permission0::Pallet::<Test>::delegate_emission_permission(
+                get_origin(agent_0),
+                recipients,
+                pallet_permission0::EmissionAllocation::Streams(streams.try_into().unwrap()),
+                pallet_permission0::DistributionControl::Manual,
+                pallet_permission0::PermissionDuration::Indefinite,
+                pallet_permission0::RevocationTerms::RevocableAfter(5),
+                pallet_permission0::EnforcementAuthority::None,
+                Some(recipient_manager),
+                None,
+            )
+        );
+
+        let permission_id = get_last_delegated_permission_id(agent_0);
+
+        // Manager cannot modify before revocable period
+        let mut new_recipients = BoundedBTreeMap::new();
+        new_recipients.try_insert(agent_1, u16::MAX / 2).unwrap();
+        new_recipients.try_insert(agent_2, u16::MAX / 2).unwrap();
+
+        assert_err!(
+            pallet_permission0::Pallet::<Test>::update_emission_permission(
+                get_origin(recipient_manager),
+                permission_id,
+                Some(new_recipients.clone()),
+                None,
+                None,
+                None,
+                None
+            ),
+            pallet_permission0::Error::<Test>::NotAuthorizedToEdit
+        );
+
+        // Wait for revocable period
         step_block(6);
+
+        // Now manager can modify
+        assert_ok!(
+            pallet_permission0::Pallet::<Test>::update_emission_permission(
+                get_origin(recipient_manager),
+                permission_id,
+                Some(new_recipients.clone()),
+                None,
+                None,
+                None,
+                None
+            )
+        );
+
+        // Verify changes were applied
+        let permission = pallet_permission0::Permissions::<Test>::get(permission_id).unwrap();
+        let pallet_permission0::PermissionScope::Emission(scope) = permission.scope else {
+            panic!("Expected emission scope");
+        };
+        assert_eq!(scope.recipients, new_recipients);
+    });
+}
+
+#[test]
+fn delegator_can_assign_and_remove_managers() {
+    new_test_ext().execute_with(|| {
+        zero_min_burn();
+        let agent_0 = 0;
+        register_empty_agent(agent_0);
+
+        let agent_1 = 1;
+        register_empty_agent(agent_1);
+
+        let weight_setter = 2;
+        register_empty_agent(weight_setter);
+
+        let recipient_manager = 3;
+        register_empty_agent(recipient_manager);
+
+        add_balance(agent_0, as_tors(10) + 1);
+
+        let stream_id = generate_root_stream_id(&agent_0);
+        let mut streams = BTreeMap::new();
+        streams.insert(stream_id, Percent::from_percent(100));
+
+        let mut recipients = BoundedBTreeMap::new();
+        recipients.try_insert(agent_1, u16::MAX).unwrap();
+
+        assert_ok!(
+            pallet_permission0::Pallet::<Test>::delegate_emission_permission(
+                get_origin(agent_0),
+                recipients,
+                pallet_permission0::EmissionAllocation::Streams(streams.try_into().unwrap()),
+                pallet_permission0::DistributionControl::Manual,
+                pallet_permission0::PermissionDuration::Indefinite,
+                pallet_permission0::RevocationTerms::RevocableByDelegator,
+                pallet_permission0::EnforcementAuthority::None,
+                None, // weight_setter
+                None, // recipient_manager
+            )
+        );
+
+        let permission_id = get_last_delegated_permission_id(agent_0);
+
+        // Delegator can assign managers
+        assert_ok!(
+            pallet_permission0::Pallet::<Test>::update_emission_permission(
+                get_origin(agent_0),
+                permission_id,
+                None,
+                None,
+                None,
+                Some(Some(recipient_manager)),
+                Some(Some(weight_setter)),
+            )
+        );
+
+        // Verify managers were assigned
+        let permission = pallet_permission0::Permissions::<Test>::get(permission_id).unwrap();
+        let pallet_permission0::PermissionScope::Emission(scope) = permission.scope else {
+            panic!("Expected emission scope");
+        };
+        assert_eq!(scope.weight_setter, Some(weight_setter));
+        assert_eq!(scope.recipient_manager, Some(recipient_manager));
+
+        // Now managers can operate within their permissions
+        let mut new_recipients = BoundedBTreeMap::new();
+        new_recipients.try_insert(agent_1, u16::MAX / 2).unwrap();
+
+        assert_ok!(
+            pallet_permission0::Pallet::<Test>::update_emission_permission(
+                get_origin(weight_setter),
+                permission_id,
+                Some(new_recipients.clone()),
+                None,
+                None,
+                None,
+                None
+            )
+        );
+
+        // Delegator can remove managers using Some(None)
+        assert_ok!(
+            pallet_permission0::Pallet::<Test>::update_emission_permission(
+                get_origin(agent_0),
+                permission_id,
+                None,
+                None,
+                None,
+                Some(None), // Remove weight_setter
+                Some(None)  // Remove recipient_manager
+            )
+        );
+
+        // Verify managers were removed
+        let permission = pallet_permission0::Permissions::<Test>::get(permission_id).unwrap();
+        let pallet_permission0::PermissionScope::Emission(scope) = permission.scope else {
+            panic!("Expected emission scope");
+        };
+        assert_eq!(scope.weight_setter, None);
+        assert_eq!(scope.recipient_manager, None);
+
+        // Former managers should no longer have access
+        assert_err!(
+            pallet_permission0::Pallet::<Test>::update_emission_permission(
+                get_origin(weight_setter),
+                permission_id,
+                Some(new_recipients),
+                None,
+                None,
+                None,
+                None
+            ),
+            pallet_permission0::Error::<Test>::NotAuthorizedToEdit
+        );
+    });
+}
+
+#[test]
+fn index_consistency_during_complex_recipient_updates() {
+    new_test_ext().execute_with(|| {
+        zero_min_burn();
+        let agent_0 = 0;
+        register_empty_agent(agent_0);
+
+        let agent_1 = 1;
+        register_empty_agent(agent_1);
+
+        let agent_2 = 2;
+        register_empty_agent(agent_2);
+
+        let agent_3 = 3;
+        register_empty_agent(agent_3);
+
+        let agent_4 = 4;
+        register_empty_agent(agent_4);
+
+        add_balance(agent_0, as_tors(10) + 1);
+
+        let stream_id = generate_root_stream_id(&agent_0);
+        let mut streams = BTreeMap::new();
+        streams.insert(stream_id, Percent::from_percent(100));
+
+        let mut recipients = BoundedBTreeMap::new();
+        recipients.try_insert(agent_1, u16::MAX / 3).unwrap();
+        recipients.try_insert(agent_2, u16::MAX / 3).unwrap();
+        recipients.try_insert(agent_3, u16::MAX / 3).unwrap();
+
+        assert_ok!(
+            pallet_permission0::Pallet::<Test>::delegate_emission_permission(
+                get_origin(agent_0),
+                recipients,
+                pallet_permission0::EmissionAllocation::Streams(streams.try_into().unwrap()),
+                pallet_permission0::DistributionControl::Manual,
+                pallet_permission0::PermissionDuration::Indefinite,
+                pallet_permission0::RevocationTerms::RevocableByDelegator,
+                pallet_permission0::EnforcementAuthority::None,
+                None,
+                None,
+            )
+        );
+
+        let permission_id = get_last_delegated_permission_id(agent_0);
+
+        // Verify initial indices
+        assert!(
+            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_1)
+                .contains(&permission_id)
+        );
+        assert!(
+            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_2)
+                .contains(&permission_id)
+        );
+        assert!(
+            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_3)
+                .contains(&permission_id)
+        );
+        assert!(
+            !pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_4)
+                .contains(&permission_id)
+        );
+
+        // Complex update: remove agent_2, keep agent_1 with new weight, add agent_4
+        let mut updated_recipients = BoundedBTreeMap::new();
+        updated_recipients
+            .try_insert(agent_1, u16::MAX / 2)
+            .unwrap(); // Keep with different weight
+        updated_recipients
+            .try_insert(agent_3, u16::MAX / 4)
+            .unwrap(); // Keep with different weight  
+        updated_recipients
+            .try_insert(agent_4, u16::MAX / 4)
+            .unwrap(); // Add new
 
         assert_ok!(
             pallet_permission0::Pallet::<Test>::update_emission_permission(
                 get_origin(agent_0),
                 permission_id,
-                new_targets.clone(),
-                Some(streams.clone().try_into().unwrap()),
-                Some(pallet_permission0::DistributionControl::Interval(100))
+                Some(updated_recipients.clone()),
+                None,
+                None,
+                None,
+                None
             )
+        );
+
+        // Verify permission state is correct
+        let permission = pallet_permission0::Permissions::<Test>::get(permission_id).unwrap();
+        let pallet_permission0::PermissionScope::Emission(scope) = permission.scope else {
+            panic!("Expected emission scope");
+        };
+        assert_eq!(scope.recipients, updated_recipients);
+
+        // Verify ALL indices are consistent
+        assert!(
+            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_1)
+                .contains(&permission_id)
+        ); // Still there
+        assert!(
+            !pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_2)
+                .contains(&permission_id)
+        ); // Removed
+        assert!(
+            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_3)
+                .contains(&permission_id)
+        ); // Still there
+        assert!(
+            pallet_permission0::PermissionsByRecipient::<Test>::get(&agent_4)
+                .contains(&permission_id)
+        ); // Added
+
+        // Verify delegator indices are also consistent
+        let delegator_permissions =
+            pallet_permission0::PermissionsByDelegator::<Test>::get(&agent_0);
+        assert!(delegator_permissions.contains(&permission_id));
+
+        // Verify participants indices include all current participants
+        let participants_1 =
+            pallet_permission0::PermissionsByParticipants::<Test>::get((&agent_0, &agent_1));
+        let participants_2 =
+            pallet_permission0::PermissionsByParticipants::<Test>::get((&agent_0, &agent_2));
+        let participants_3 =
+            pallet_permission0::PermissionsByParticipants::<Test>::get((&agent_0, &agent_3));
+        let participants_4 =
+            pallet_permission0::PermissionsByParticipants::<Test>::get((&agent_0, &agent_4));
+
+        assert!(participants_1.contains(&permission_id)); // Still there
+        assert!(!participants_2.contains(&permission_id)); // Removed
+        assert!(participants_3.contains(&permission_id)); // Still there
+        assert!(participants_4.contains(&permission_id)); // Added
+
+        // Test complete removal of all recipients should delete permission
+        let empty_recipients = BoundedBTreeMap::new();
+
+        // This should fail as permissions need at least one recipient
+        assert_err!(
+            pallet_permission0::Pallet::<Test>::update_emission_permission(
+                get_origin(agent_0),
+                permission_id,
+                Some(empty_recipients),
+                None,
+                None,
+                None,
+                None
+            ),
+            pallet_permission0::Error::<Test>::NoTargetsSpecified
         );
     });
 }

--- a/runtime/src/configs.rs
+++ b/runtime/src/configs.rs
@@ -464,7 +464,7 @@ parameter_types! {
     pub const MaxControllersPerPermission: u32 = 10;
     pub const MaxRevokersPerPermission: u32 = 10;
 
-    pub const MaxTargetsPerPermission: u32 = 100;
+    pub const MaxRecipientsPerPermission: u32 = 100;
     pub const MaxStreamsPerPermission: u32 = 100;
     pub const MinAutoDistributionThreshold: u128 = as_tors(100);
 
@@ -487,7 +487,7 @@ impl pallet_permission0::Config for Runtime {
     type MaxControllersPerPermission = MaxControllersPerPermission;
     type MaxRevokersPerPermission = MaxRevokersPerPermission;
 
-    type MaxTargetsPerPermission = MaxTargetsPerPermission;
+    type MaxRecipientsPerPermission = MaxRecipientsPerPermission;
     type MaxStreamsPerPermission = MaxStreamsPerPermission;
     type MinAutoDistributionThreshold = MinAutoDistributionThreshold;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -37,7 +37,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("torus-runtime"),
     impl_name: create_runtime_str!("torus-runtime"),
     authoring_version: 1,
-    spec_version: 23,
+    spec_version: 24,
     impl_version: 1,
     apis: apis::RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -82,7 +82,8 @@ pub type SignedPayload = sp_runtime::generic::SignedPayload<RuntimeCall, SignedE
 /// All migrations of the runtime, aside from the ones declared in the pallets.
 ///
 /// This can be a tuple of types, each implementing `OnRuntimeUpgrade`.
-type Migrations = ();
+type Migrations =
+    (pallet_permission0::migrations::v6::Migration<Runtime, weights::constants::RocksDbWeight>,);
 
 /// Executive: handles dispatch to the various modules.
 pub type RuntimeExecutive = frame_executive::Executive<

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -239,7 +239,7 @@ impl pallet_governance::Config for Test {
 
 parameter_types! {
     pub const PermissionPalletId: PalletId = PalletId(*b"torusper");
-    pub const MaxTargetsPerPermission: u32 = 100;
+    pub const MaxRecipientsPerPermission: u32 = 100;
     pub const MaxStreamsPerPermission: u32 = 100;
     pub const MaxRevokersPerPermission: u32 = 10;
     pub const MaxControllersPerPermission: u32 = 10;
@@ -257,7 +257,7 @@ impl pallet_permission0::Config for Test {
 
     type PalletId = PermissionPalletId;
 
-    type MaxTargetsPerPermission = MaxTargetsPerPermission;
+    type MaxRecipientsPerPermission = MaxRecipientsPerPermission;
 
     type MaxStreamsPerPermission = MaxStreamsPerPermission;
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -431,9 +431,8 @@ pub type NegativeImbalanceOf = <pallet_balances::Pallet<Test> as Currency<
 #[allow(clippy::too_many_arguments)]
 pub fn delegate_emission_permission(
     delegator: AccountId,
-    recipient: AccountId,
+    recipients: Vec<(AccountId, u16)>,
     allocation: pallet_permission0_api::EmissionAllocation<Balance>,
-    targets: Vec<(AccountId, u16)>,
     distribution: pallet_permission0_api::DistributionControl<Balance, BlockNumber>,
     duration: pallet_permission0_api::PermissionDuration<BlockNumber>,
     revocation: pallet_permission0_api::RevocationTerms<AccountId, BlockNumber>,
@@ -448,13 +447,14 @@ pub fn delegate_emission_permission(
         NegativeImbalanceOf,
     >>::delegate_emission_permission(
         delegator,
-        recipient,
+        recipients,
         allocation,
-        targets,
         distribution,
         duration,
         revocation,
         enforcement,
+        None,
+        None,
     )
 }
 


### PR DESCRIPTION
This change is a big one. We are moving the recipient field to within each scope. This allows the scope to decide how to handle recipients. On emissions, for example, we are bridging the gap that existed between the targets and the recipient, which confusion before: targets are now the recipients of the permissions. Just as before, a recipient can auto-revoke the permission, and in case it is of an emission type, this only means removing itself from the list of recipients without deleting it (in case there are more recipients).

Closes CHAIN-122, CHAIN-124.