### PR TITLE
feat(permission0): bulk namespace creation

### DIFF
--- a/pallets/faucet/tests/faucet.rs
+++ b/pallets/faucet/tests/faucet.rs
@@ -263,6 +263,7 @@ impl pallet_permission0::Config for Test {
     type MaxNamespacesPerPermission = ConstU32<0>;
     type MaxChildrenPerPermission = ConstU32<0>;
     type MaxCuratorSubpermissionsPerPermission = ConstU32<0>;
+    type MaxBulkOperationsPerCall = ConstU32<20>;
 }
 
 impl pallet_balances::Config for Test {

--- a/runtime/src/configs.rs
+++ b/runtime/src/configs.rs
@@ -471,6 +471,7 @@ parameter_types! {
     pub const MaxNamespacesPerPermission: u32 = 16;
     pub const MaxChildrenPerPermission: u32 = 16;
     pub const MaxCuratorSubpermissionsPerPermission: u32 = 16;
+    pub const MaxBulkOperationsPerCall: u32 = 20;
 }
 
 impl pallet_permission0::Config for Runtime {
@@ -494,6 +495,7 @@ impl pallet_permission0::Config for Runtime {
     type MaxNamespacesPerPermission = MaxNamespacesPerPermission;
     type MaxChildrenPerPermission = MaxChildrenPerPermission;
     type MaxCuratorSubpermissionsPerPermission = MaxCuratorSubpermissionsPerPermission;
+    type MaxBulkOperationsPerCall = MaxBulkOperationsPerCall;
 }
 
 impl pallet_faucet::Config for Runtime {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -270,6 +270,7 @@ impl pallet_permission0::Config for Test {
     type MaxNamespacesPerPermission = ConstU32<10>;
     type MaxChildrenPerPermission = ConstU32<10>;
     type MaxCuratorSubpermissionsPerPermission = ConstU32<10>;
+    type MaxBulkOperationsPerCall = ConstU32<20>;
 }
 
 impl pallet_balances::Config for Test {


### PR DESCRIPTION
Adding an extrinsic allowing creation of multiple namespace permissions in a single call. This is rather useful for big agents during swarm creation.