### PR TITLE
refac(permission0): move max instances and children to scope

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ check: fmt
   cargo clippy --tests
 
 test: check
-  cargo nextest run
+  SKIP_WASM_BUILD=1 cargo nextest run
 
 fmt:
   cargo fmt

--- a/pallets/permission0/src/ext/stream_impl.rs
+++ b/pallets/permission0/src/ext/stream_impl.rs
@@ -166,14 +166,8 @@ pub(crate) fn delegate_stream_permission_impl<T: Config>(
 
     let permission_id = generate_permission_id::<T>(&delegator, &scope)?;
 
-    let contract = PermissionContract::<T>::new(
-        delegator.clone(),
-        scope,
-        duration,
-        revocation,
-        enforcement,
-        1,
-    );
+    let contract =
+        PermissionContract::<T>::new(delegator.clone(), scope, duration, revocation, enforcement);
 
     Permissions::<T>::insert(permission_id, contract);
 

--- a/pallets/permission0/src/lib.rs
+++ b/pallets/permission0/src/lib.rs
@@ -38,7 +38,7 @@ pub mod pallet {
 
     use super::*;
 
-    const STORAGE_VERSION: StorageVersion = StorageVersion::new(6);
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(7);
 
     /// Configure the pallet by specifying the parameters and types on which it depends.
     #[pallet::config]

--- a/pallets/permission0/src/migrations.rs
+++ b/pallets/permission0/src/migrations.rs
@@ -1,7 +1,7 @@
-pub mod v6 {
+pub mod v7 {
     use polkadot_sdk::{
         frame_support::{migrations::VersionedMigration, traits::UncheckedOnRuntimeUpgrade},
-        sp_runtime::BoundedBTreeSet,
+        sp_std::{vec, vec::Vec},
         sp_tracing::{error, info, warn},
         sp_weights::Weight,
     };
@@ -9,44 +9,67 @@ pub mod v6 {
     use crate::{
         Config, Pallet, PermissionContract, PermissionScope, Permissions, PermissionsByDelegator,
         PermissionsByParticipants, PermissionsByRecipient, StreamScope,
+        permission::add_permission_indices,
         permission::{CuratorScope, NamespaceScope},
-        permission::{add_permission_indices, remove_permission_from_indices},
     };
 
-    pub type Migration<T, W> = VersionedMigration<5, 6, MigrateToV6<T>, Pallet<T>, W>;
-    pub struct MigrateToV6<T>(core::marker::PhantomData<T>);
+    pub type Migration<T, W> = VersionedMigration<6, 7, MigrateToV7<T>, Pallet<T>, W>;
+    pub struct MigrateToV7<T>(core::marker::PhantomData<T>);
 
     mod old_storage {
         use codec::{Decode, Encode, MaxEncodedLen};
+        use pallet_torus0_api::NamespacePath;
         use polkadot_sdk::{
             frame_support::Identity,
             frame_support_procedural::storage_alias,
-            polkadot_sdk_frame::prelude::BlockNumberFor,
-            sp_runtime::{BoundedBTreeMap, BoundedBTreeSet},
+            polkadot_sdk_frame::prelude::{BlockNumberFor, ValueQuery},
+            sp_runtime::{BoundedBTreeMap, BoundedBTreeSet, BoundedVec},
         };
         use scale_info::TypeInfo;
 
-        use crate::{Config, DistributionControl, Pallet, PermissionId, StreamAllocation};
+        use crate::{
+            AccountIdOf, Config, CuratorPermissions, EnforcementAuthority, Pallet,
+            PermissionDuration, PermissionId, RevocationTerms, StreamScope,
+        };
 
         #[storage_alias]
         pub type Permissions<T: Config> =
             StorageMap<Pallet<T>, Identity, PermissionId, OldPermissionContract<T>>;
 
-        #[derive(Encode, Decode, TypeInfo, MaxEncodedLen)]
-        #[scale_info(skip_type_params(T))]
-        pub struct OldEmissionScope<T: Config> {
-            pub allocation: StreamAllocation<T>,
-            pub distribution: DistributionControl<T>,
-            pub targets: BoundedBTreeMap<T::AccountId, u16, T::MaxRecipientsPerPermission>,
-            pub accumulating: bool,
-        }
+        #[storage_alias]
+        pub type PermissionsByParticipants<T: Config> = StorageMap<
+            Pallet<T>,
+            Identity,
+            (AccountIdOf<T>, AccountIdOf<T>),
+            BoundedVec<PermissionId, <T as Config>::MaxRecipientsPerPermission>,
+            ValueQuery,
+        >;
+
+        #[storage_alias]
+        pub type PermissionsByDelegator<T: Config> = StorageMap<
+            Pallet<T>,
+            Identity,
+            AccountIdOf<T>,
+            BoundedVec<PermissionId, <T as Config>::MaxRecipientsPerPermission>,
+            ValueQuery,
+        >;
+
+        #[storage_alias]
+        pub type PermissionsByRecipient<T: Config> = StorageMap<
+            Pallet<T>,
+            Identity,
+            AccountIdOf<T>,
+            BoundedVec<PermissionId, <T as Config>::MaxRecipientsPerPermission>,
+            ValueQuery,
+        >;
 
         #[derive(Encode, Decode, TypeInfo, MaxEncodedLen)]
         #[scale_info(skip_type_params(T))]
         pub struct OldCuratorScope<T: Config> {
+            pub recipient: T::AccountId,
             pub flags: BoundedBTreeMap<
                 Option<PermissionId>,
-                crate::CuratorPermissions,
+                CuratorPermissions,
                 T::MaxCuratorSubpermissionsPerPermission,
             >,
             pub cooldown: Option<BlockNumberFor<T>>,
@@ -55,9 +78,10 @@ pub mod v6 {
         #[derive(Encode, Decode, TypeInfo, MaxEncodedLen)]
         #[scale_info(skip_type_params(T))]
         pub struct OldNamespaceScope<T: Config> {
+            pub recipient: T::AccountId,
             pub paths: BoundedBTreeMap<
                 Option<PermissionId>,
-                BoundedBTreeSet<pallet_torus0_api::NamespacePath, T::MaxNamespacesPerPermission>,
+                BoundedBTreeSet<NamespacePath, T::MaxNamespacesPerPermission>,
                 T::MaxNamespacesPerPermission,
             >,
         }
@@ -65,7 +89,7 @@ pub mod v6 {
         #[derive(Encode, Decode, TypeInfo, MaxEncodedLen)]
         #[scale_info(skip_type_params(T))]
         pub enum OldPermissionScope<T: Config> {
-            Emission(OldEmissionScope<T>),
+            Stream(StreamScope<T>),
             Curator(OldCuratorScope<T>),
             Namespace(OldNamespaceScope<T>),
         }
@@ -74,12 +98,18 @@ pub mod v6 {
         #[scale_info(skip_type_params(T))]
         pub struct OldPermissionContract<T: Config> {
             pub delegator: T::AccountId,
-            pub recipient: T::AccountId,
             pub scope: OldPermissionScope<T>,
-            pub duration: crate::permission::PermissionDuration<T>,
-            pub revocation: crate::RevocationTerms<T>,
-            pub enforcement: crate::permission::EnforcementAuthority<T>,
+            pub duration: PermissionDuration<T>,
+            pub revocation: RevocationTerms<T>,
+            /// Enforcement authority that can toggle the permission
+            pub enforcement: EnforcementAuthority<T>,
+            /// Last update block
+            pub last_update: BlockNumberFor<T>,
+            /// Last execution block
+            #[doc(hidden)]
             pub last_execution: Option<BlockNumberFor<T>>,
+            /// Number of times the permission was executed
+            #[doc(hidden)]
             pub execution_count: u32,
             pub max_instances: u32,
             pub children: polkadot_sdk::sp_runtime::BoundedBTreeSet<
@@ -90,79 +120,74 @@ pub mod v6 {
         }
     }
 
-    impl<T: Config> UncheckedOnRuntimeUpgrade for MigrateToV6<T> {
+    impl<T: Config> UncheckedOnRuntimeUpgrade for MigrateToV7<T> {
         fn on_runtime_upgrade() -> Weight {
-            let mut migrated_count = 0u32;
-            let mut emission_permissions_updated = 0u32;
-            let mut curator_permissions_updated = 0u32;
-            let mut namespace_permissions_updated = 0u32;
+            let _ = old_storage::PermissionsByDelegator::<T>::clear(u32::MAX, None);
+            let _ = old_storage::PermissionsByRecipient::<T>::clear(u32::MAX, None);
+            let _ = old_storage::PermissionsByParticipants::<T>::clear(u32::MAX, None);
+
+            let _ = crate::PermissionsByDelegator::<T>::clear(u32::MAX, None);
+            let _ = crate::PermissionsByRecipient::<T>::clear(u32::MAX, None);
+            let _ = crate::PermissionsByParticipants::<T>::clear(u32::MAX, None);
 
             for (permission_id, old_contract) in old_storage::Permissions::<T>::iter() {
                 let new_scope = match old_contract.scope {
-                    old_storage::OldPermissionScope::Emission(old_emission) => {
-                        emission_permissions_updated =
-                            emission_permissions_updated.saturating_add(1);
-
-                        // For emission permissions, we need to update storage indices:
-                        // 1. Remove the old recipient index (permission recipient)
-                        // 2. Add indices for all the emission targets
-
-                        // Remove old recipient index
-                        remove_permission_from_indices::<T>(
-                            &old_contract.delegator,
-                            core::iter::once(&old_contract.recipient),
-                            permission_id,
-                        );
-
-                        let mut managers = BoundedBTreeSet::new();
-                        let _ = managers.try_insert(old_contract.delegator.clone());
-
-                        let new_emission = StreamScope::<T> {
-                            recipients: old_emission.targets, // Field renamed from targets to recipients
-                            allocation: old_emission.allocation,
-                            distribution: old_emission.distribution,
-                            accumulating: old_emission.accumulating,
-                            // New manager fields introduced in v6
-                            recipient_managers: managers.clone(),
-                            weight_setters: managers,
-                        };
-
-                        // Add new indices for all emission targets
+                    old_storage::OldPermissionScope::Stream(stream) => {
                         if let Err(e) = add_permission_indices::<T>(
                             &old_contract.delegator,
-                            new_emission.recipients.keys(),
+                            stream.recipients.keys(),
                             permission_id,
                         ) {
                             error!(
-                                "Failed to add permission indices for emission permission {permission_id:?}: {e:?}"
+                                "Failed to add permission indices for stream permission {permission_id:?}: {e:?}"
                             );
                         }
 
-                        PermissionScope::Stream(new_emission)
+                        PermissionScope::Stream(stream)
                     }
                     old_storage::OldPermissionScope::Curator(old_curator) => {
-                        curator_permissions_updated = curator_permissions_updated.saturating_add(1);
+                        if let Err(e) = add_permission_indices::<T>(
+                            &old_contract.delegator,
+                            core::iter::once(&old_curator.recipient),
+                            permission_id,
+                        ) {
+                            error!(
+                                "Failed to add permission indices for curator permission {permission_id:?}: {e:?}"
+                            );
+                        }
 
                         let new_curator = crate::permission::CuratorScope::<T> {
-                            recipient: old_contract.recipient.clone(), // Add recipient field from contract
+                            recipient: old_curator.recipient,
                             flags: old_curator.flags,
                             cooldown: old_curator.cooldown,
+                            max_instances: old_contract.max_instances,
+                            children: old_contract.children,
                         };
 
                         PermissionScope::Curator(new_curator)
                     }
                     old_storage::OldPermissionScope::Namespace(old_namespace) => {
-                        namespace_permissions_updated =
-                            namespace_permissions_updated.saturating_add(1);
+                        if let Err(e) = add_permission_indices::<T>(
+                            &old_contract.delegator,
+                            core::iter::once(&old_namespace.recipient),
+                            permission_id,
+                        ) {
+                            error!(
+                                "Failed to add permission indices for namespace permission {permission_id:?}: {e:?}"
+                            );
+                        }
 
                         let new_namespace = crate::permission::NamespaceScope::<T> {
-                            recipient: old_contract.recipient.clone(), // Add recipient field from contract
+                            recipient: old_namespace.recipient,
                             paths: old_namespace.paths,
+                            max_instances: old_contract.max_instances,
+                            children: old_contract.children,
                         };
 
                         PermissionScope::Namespace(new_namespace)
                     }
                 };
+
                 let new_contract = PermissionContract::<T> {
                     delegator: old_contract.delegator,
                     scope: new_scope,
@@ -172,21 +197,11 @@ pub mod v6 {
                     last_update: old_contract.created_at,
                     last_execution: old_contract.last_execution,
                     execution_count: old_contract.execution_count,
-                    children: old_contract.children,
                     created_at: old_contract.created_at,
-                    max_instances: old_contract.max_instances,
                 };
 
                 crate::Permissions::<T>::set(permission_id, Some(new_contract));
-                migrated_count = migrated_count.saturating_add(1);
             }
-
-            info!(
-                "Permission0 migration v5→v6 completed: {migrated_count} total permissions migrated \
-| Emission: {emission_permissions_updated} (targets→recipients, manager fields added) \
-| Curator: {curator_permissions_updated} (recipient field added) \
-| Namespace: {namespace_permissions_updated} (recipient field added)",
-            );
 
             check_all_indices_consistency::<T>();
 
@@ -205,6 +220,8 @@ pub mod v6 {
             total_inconsistencies.saturating_add(check_recipient_indices_consistency::<T>());
         total_inconsistencies =
             total_inconsistencies.saturating_add(check_participant_indices_consistency::<T>());
+        total_inconsistencies =
+            total_inconsistencies.saturating_add(check_permissions_are_indexed::<T>());
 
         if total_inconsistencies == 0 {
             info!("All permission0 indices are consistent!");
@@ -348,6 +365,66 @@ pub mod v6 {
             warn!("Found {inconsistencies} participant index inconsistencies");
         } else {
             info!("Participant indices are consistent");
+        }
+
+        inconsistencies
+    }
+
+    /// Check that all permissions in storage are properly indexed
+    /// This is the counterpart function that verifies all permissions have correct index entries
+    pub fn check_permissions_are_indexed<T: Config>() -> u32 {
+        let mut inconsistencies = 0u32;
+
+        info!("Checking that all permissions in storage are properly indexed...");
+
+        for (permission_id, contract) in Permissions::<T>::iter() {
+            let delegator = &contract.delegator;
+
+            let delegator_indices = PermissionsByDelegator::<T>::get(delegator);
+            if !delegator_indices.contains(&permission_id) {
+                error!(
+                    "Missing delegator index: Permission {permission_id:?} with delegator {delegator:?} \
+                    is not in PermissionsByDelegator index"
+                );
+                inconsistencies = inconsistencies.saturating_add(1);
+            }
+
+            let recipients: Vec<T::AccountId> = match &contract.scope {
+                PermissionScope::Stream(StreamScope { recipients, .. }) => {
+                    recipients.keys().cloned().collect()
+                }
+                PermissionScope::Curator(CuratorScope { recipient, .. })
+                | PermissionScope::Namespace(NamespaceScope { recipient, .. }) => {
+                    vec![recipient.clone()]
+                }
+            };
+
+            for recipient in recipients.iter() {
+                let recipient_indices = PermissionsByRecipient::<T>::get(recipient);
+                if !recipient_indices.contains(&permission_id) {
+                    error!(
+                        "Missing recipient index: Permission {permission_id:?} with recipient {recipient:?} \
+                        is not in PermissionsByRecipient index"
+                    );
+                    inconsistencies = inconsistencies.saturating_add(1);
+                }
+
+                let participant_indices =
+                    PermissionsByParticipants::<T>::get((delegator.clone(), recipient.clone()));
+                if !participant_indices.contains(&permission_id) {
+                    error!(
+                        "Missing participant index: Permission {permission_id:?} with participants \
+                        ({delegator:?}, {recipient:?}) is not in PermissionsByParticipants index"
+                    );
+                    inconsistencies = inconsistencies.saturating_add(1);
+                }
+            }
+        }
+
+        if inconsistencies > 0 {
+            warn!("Found {inconsistencies} missing index entries for existing permissions");
+        } else {
+            info!("All permissions are properly indexed");
         }
 
         inconsistencies

--- a/pallets/permission0/src/permission/namespace.rs
+++ b/pallets/permission0/src/permission/namespace.rs
@@ -1,0 +1,46 @@
+use codec::{Decode, Encode, MaxEncodedLen};
+use pallet_torus0_api::NamespacePath;
+use polkadot_sdk::{
+    frame_support::{CloneNoBound, DebugNoBound},
+    sp_runtime::{BoundedBTreeMap, BoundedBTreeSet},
+};
+use scale_info::TypeInfo;
+
+use crate::{Config, Permissions};
+
+use super::PermissionId;
+
+/// Scope for namespace permissions
+#[derive(Encode, Decode, CloneNoBound, TypeInfo, MaxEncodedLen, DebugNoBound)]
+#[scale_info(skip_type_params(T))]
+pub struct NamespaceScope<T: Config> {
+    pub recipient: T::AccountId,
+    /// Set of namespace paths this permission delegates access to
+    pub paths: BoundedBTreeMap<
+        Option<PermissionId>,
+        BoundedBTreeSet<NamespacePath, T::MaxNamespacesPerPermission>,
+        T::MaxNamespacesPerPermission,
+    >,
+    /// Maximum number of instances of this permission
+    pub max_instances: u32,
+    /// Children permissions
+    pub children: BoundedBTreeSet<PermissionId, T::MaxChildrenPerPermission>,
+}
+
+impl<T: Config> NamespaceScope<T> {
+    /// Cleanup operations when permission is revoked or expired
+    pub(super) fn cleanup(
+        &self,
+        permission_id: polkadot_sdk::sp_core::H256,
+        _last_execution: &Option<crate::BlockNumberFor<T>>,
+        _delegator: &T::AccountId,
+    ) {
+        for pid in self.paths.keys().cloned().flatten() {
+            Permissions::<T>::mutate_extant(pid, |parent| {
+                if let Some(children) = parent.children_mut() {
+                    children.remove(&permission_id);
+                }
+            });
+        }
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -37,7 +37,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("torus-runtime"),
     impl_name: create_runtime_str!("torus-runtime"),
     authoring_version: 1,
-    spec_version: 24,
+    spec_version: 25,
     impl_version: 1,
     apis: apis::RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -83,7 +83,7 @@ pub type SignedPayload = sp_runtime::generic::SignedPayload<RuntimeCall, SignedE
 ///
 /// This can be a tuple of types, each implementing `OnRuntimeUpgrade`.
 type Migrations =
-    (pallet_permission0::migrations::v6::Migration<Runtime, weights::constants::RocksDbWeight>,);
+    (pallet_permission0::migrations::v7::Migration<Runtime, weights::constants::RocksDbWeight>,);
 
 /// Executive: handles dispatch to the various modules.
 pub type RuntimeExecutive = frame_executive::Executive<


### PR DESCRIPTION
Moves `max_instances` and `children` to within the scopes.

Closes CHAIN-127.