### PR TITLE
chore(permission0): allow 0 weight recipients

### DIFF
--- a/pallets/permission0/src/ext/stream_impl.rs
+++ b/pallets/permission0/src/ext/stream_impl.rs
@@ -451,7 +451,10 @@ fn validate_stream_permission_recipients<T: Config>(
 
     for (recipient, weight) in recipients {
         ensure!(delegator != recipient, Error::<T>::InvalidRecipientWeight);
-        ensure!(*weight > 0, Error::<T>::InvalidRecipientWeight);
+        ensure!(
+            revocation.is_revokable() || *weight > 0,
+            Error::<T>::InvalidRecipientWeight
+        );
         ensure!(
             T::Torus::is_agent_registered(recipient),
             Error::<T>::NotRegisteredAgent

--- a/pallets/permission0/tests/lifetime.rs
+++ b/pallets/permission0/tests/lifetime.rs
@@ -39,6 +39,19 @@ fn irrevocable() {
         let agent_1 = bob();
         let agent_2 = charlie();
 
+        assert_err!(
+            delegate_stream_permission(
+                agent_0,
+                vec![(agent_1, 0), (agent_2, u16::MAX / 2)],
+                pallet_permission0_api::StreamAllocation::FixedAmount(as_tors(10)),
+                pallet_permission0_api::DistributionControl::Manual,
+                pallet_permission0_api::PermissionDuration::Indefinite,
+                pallet_permission0_api::RevocationTerms::Irrevocable,
+                pallet_permission0_api::EnforcementAuthority::None,
+            ),
+            Error::<Test>::InvalidRecipientWeight
+        );
+
         let permission_id = assert_ok!(delegate_stream_permission(
             agent_0,
             vec![(agent_1, u16::MAX / 2), (agent_2, u16::MAX / 2)],
@@ -81,7 +94,7 @@ fn revocable_by_delegator() {
 
         let permission_id = assert_ok!(delegate_stream_permission(
             agent_0,
-            vec![(agent_1, u16::MAX / 2), (agent_2, u16::MAX / 2)],
+            vec![(agent_1, 0), (agent_2, u16::MAX / 2)],
             pallet_permission0_api::StreamAllocation::FixedAmount(as_tors(10)),
             pallet_permission0_api::DistributionControl::Manual,
             pallet_permission0_api::PermissionDuration::Indefinite,
@@ -127,6 +140,19 @@ fn revocable_after_block() {
         let agent_0 = alice();
         let agent_1 = bob();
         let agent_2 = charlie();
+
+        assert_err!(
+            delegate_stream_permission(
+                agent_0,
+                vec![(agent_1, 0), (agent_2, u16::MAX / 2)],
+                pallet_permission0_api::StreamAllocation::FixedAmount(as_tors(10)),
+                pallet_permission0_api::DistributionControl::Manual,
+                pallet_permission0_api::PermissionDuration::Indefinite,
+                pallet_permission0_api::RevocationTerms::RevocableAfter(2),
+                pallet_permission0_api::EnforcementAuthority::None,
+            ),
+            Error::<Test>::InvalidRecipientWeight
+        );
 
         let permission_id = assert_ok!(delegate_stream_permission(
             agent_0,


### PR DESCRIPTION
This patch allows recipients to have 0 weights when permissions are updatable. This plays along recipient managers.

Closes CHAIN-138.