### PR TITLE
[codex] Fix Frontier pending block inherents

### DIFF
--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -163,6 +163,30 @@ type AuraData = Pin<
     >,
 >;
 
+fn aura_inherent_data_providers(
+    timestamp: sp_timestamp::InherentDataProvider,
+    slot_duration: sp_consensus_aura::SlotDuration,
+    target_gas_price: u64,
+) -> InherentDataProviders {
+    let slot = sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+        *timestamp,
+        slot_duration,
+    );
+    let dynamic_fee = fp_dynamic_fee::InherentDataProvider(target_gas_price.into());
+    (slot, timestamp, dynamic_fee)
+}
+
+fn aura_next_slot_timestamp(
+    current: sp_timestamp::InherentDataProvider,
+    slot_duration: sp_consensus_aura::SlotDuration,
+) -> sp_timestamp::InherentDataProvider {
+    let next_slot = current
+        .timestamp()
+        .as_millis()
+        .saturating_add(slot_duration.as_millis());
+    sp_timestamp::InherentDataProvider::new(next_slot.into())
+}
+
 fn aura_data_provider(
     slot_duration: sp_consensus_aura::SlotDuration,
     target_gas_price: u64,
@@ -170,13 +194,28 @@ fn aura_data_provider(
     move |_, ()| {
         Box::pin(async move {
             let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
-            let slot =
-            sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
-                *timestamp,
+            Ok(aura_inherent_data_providers(
+                timestamp,
                 slot_duration,
-            );
-            let dynamic_fee = fp_dynamic_fee::InherentDataProvider(target_gas_price.into());
-            Ok((slot, timestamp, dynamic_fee))
+                target_gas_price,
+            ))
+        })
+    }
+}
+
+fn aura_pending_data_provider(
+    slot_duration: sp_consensus_aura::SlotDuration,
+    target_gas_price: u64,
+) -> impl Fn(sp_core::H256, ()) -> AuraData {
+    move |_, ()| {
+        Box::pin(async move {
+            let current = sp_timestamp::InherentDataProvider::from_system_time();
+            let timestamp = aura_next_slot_timestamp(current, slot_duration);
+            Ok(aura_inherent_data_providers(
+                timestamp,
+                slot_duration,
+                target_gas_price,
+            ))
         })
     }
 }
@@ -553,7 +592,7 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
                 fee_history_cache_limit,
                 execute_gas_limit_multiplier: eth_config.execute_gas_limit_multiplier,
                 forced_parent_hashes: None,
-                pending_create_inherent_data_providers: aura_data_provider(
+                pending_create_inherent_data_providers: aura_pending_data_provider(
                     slot_duration,
                     eth_config.target_gas_price,
                 ),
@@ -602,4 +641,19 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 
     network_starter.start_network();
     Ok(task_manager)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aura_next_slot_timestamp_advances_by_slot_duration() {
+        let current = sp_timestamp::InherentDataProvider::new(1_000_u64.into());
+        let slot_duration = sp_consensus_aura::SlotDuration::from_millis(6_000);
+
+        let timestamp = aura_next_slot_timestamp(current, slot_duration);
+
+        assert_eq!(timestamp.timestamp().as_millis(), 7_000);
+    }
 }

--- a/pallets/torus0/src/lib.rs
+++ b/pallets/torus0/src/lib.rs
@@ -34,7 +34,7 @@ use crate::{agent::Agent, burn::BurnConfiguration, fee::ValidatorFeeConstraints}
 
 #[frame::pallet]
 pub mod pallet {
-    const STORAGE_VERSION: StorageVersion = StorageVersion::new(6);
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(7);
 
     use frame::prelude::BlockNumberFor;
     use pallet_emission0_api::Emission0Api;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -37,7 +37,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("torus-runtime"),
     impl_name: create_runtime_str!("torus-runtime"),
     authoring_version: 1,
-    spec_version: 27,
+    spec_version: 28,
     impl_version: 1,
     apis: apis::RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Summary

This fixes Frontier pending-block construction for the Aura runtime path.

The node was using the same Aura inherent data provider for normal block production/import and for Frontier's pending-block RPC execution. Pending-block execution needs to simulate the next block, so it must use inherent data for the next slot. Reusing the current-slot provider can make Aura see a non-increasing slot while initializing the pending block, which aborts the runtime API call and surfaces through Ethereum RPC as an internal server error.

This shows up in Forge and other EVM tooling as failures from calls such as deployment gas estimation or pending-state requests, with errors like:

```text
Create pending runtime api error: Failed to call runtime API
Execution aborted due to trap: wasm `unreachable` instruction executed
```

## What Changed

- Split Aura inherent provider construction into reusable helpers.
- Kept normal Aura consensus import/authoring on the current system-time slot.
- Added a dedicated Frontier pending-block provider that advances the timestamp by one Aura slot before deriving Aura inherent data.
- Kept the dynamic-fee inherent provider included in both current and pending paths.
- Wired `EthDeps.pending_create_inherent_data_providers` to the pending provider only.
- Added a focused unit test covering the one-slot timestamp advance.
- Bumped runtime `spec_version` to `28`.
- Reconciled `Torus0` in-code storage version with the on-chain storage version so try-runtime validates the upgrade against current mainnet state.
- Included the storage-version bump because chain history confirmed `Torus0` pallet version moved `6 -> 7` at block `#4883721`.

## Why This Fixes It

Aura requires block slots to increase. A pending block is not an imported consensus block, but Frontier still builds it through runtime APIs using inherent data. If the pending block is initialized with the same slot as the parent/current block, Aura initialization can trip its slot-increase invariant and panic inside Wasm.

The new pending provider gives Frontier a timestamp one slot in the future, so the derived Aura slot is valid for simulated pending-block execution. Consensus import and authoring keep using the current-slot provider, so normal block production behavior is unchanged.

The `Torus0` storage-version change is included to match already-observed chain state. Without this reconciliation, try-runtime sees on-chain `Torus0` storage version `7` against in-code storage version `6` and reports the runtime as missing the storage-version context needed for the upgrade check.

## Validation

- `cargo fmt`
- `cargo clippy`
- `cargo test -p torus-node aura_next_slot_timestamp_advances_by_slot_duration`
- `try-runtime --runtime target/release/wbuild/torus-runtime/torus_runtime.compact.compressed.wasm on-runtime-upgrade --blocktime 8000 live --uri wss://api.torus.network`

## Deployment Notes

This includes both node-service logic and a runtime version bump. The Forge-facing fix requires running node binaries with the updated Frontier pending-block provider. The runtime version bump keeps the release aligned with the runtime artifact used for upgrade validation.