### PR TITLE
[codex] Add in-memory keystore flag

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -51,6 +51,30 @@ pub struct Cli {
     #[arg(long, default_value = "aura")]
     pub consensus: Consensus,
 
+    /// Keep session keys only in memory.
+    ///
+    /// This disables the on-disk keystore entirely. Keys must be injected at
+    /// runtime through RPC and are lost on restart.
+    #[arg(
+        long,
+        conflicts_with_all = [
+            "alice",
+            "bob",
+            "charlie",
+            "dave",
+            "dev",
+            "eve",
+            "ferdie",
+            "keystore_path",
+            "one",
+            "password",
+            "password_filename",
+            "password_interactive",
+            "two"
+        ]
+    )]
+    pub keystore_in_memory: bool,
+
     #[clap(flatten)]
     pub run: RunCmd,
 
@@ -92,4 +116,53 @@ pub enum Subcommand {
     /// Sub-commands concerned with benchmarking.
     #[command(subcommand)]
     Benchmark(frame_benchmarking_cli::BenchmarkCmd),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Parser, error::ErrorKind};
+
+    #[test]
+    fn parses_keystore_in_memory_flag() {
+        let cli = Cli::try_parse_from([
+            "torus-node",
+            "--chain",
+            "dev",
+            "--validator",
+            "--keystore-in-memory",
+        ])
+        .expect("valid CLI arguments");
+
+        assert!(cli.keystore_in_memory);
+    }
+
+    #[test]
+    fn rejects_keystore_in_memory_with_on_disk_keystore_path() {
+        let error = Cli::try_parse_from([
+            "torus-node",
+            "--keystore-in-memory",
+            "--keystore-path",
+            "/tmp/torus-keystore",
+        ])
+        .expect_err("conflicting keystore options should fail");
+
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn rejects_keystore_in_memory_with_dev_key_shortcuts() {
+        let error = Cli::try_parse_from(["torus-node", "--keystore-in-memory", "--alice"])
+            .expect_err("dev key shortcuts should fail");
+
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn rejects_keystore_in_memory_with_dev_mode() {
+        let error = Cli::try_parse_from(["torus-node", "--keystore-in-memory", "--dev"])
+            .expect_err("dev mode should fail");
+
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+    }
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -18,7 +18,11 @@
 use benchmarking::{RemarkBuilder, TransferKeepAliveBuilder, inherent_benchmark_data};
 use frame_benchmarking_cli::{BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE};
 use futures::TryFutureExt;
-use polkadot_sdk::{sc_cli::SubstrateCli, sc_service::PartialComponents, *};
+use polkadot_sdk::{
+    sc_cli::SubstrateCli,
+    sc_service::{Configuration, PartialComponents, config::KeystoreConfig},
+    *,
+};
 use torus_runtime::interface::Block;
 
 use crate::{
@@ -28,6 +32,22 @@ use crate::{
 };
 
 mod benchmarking;
+
+fn selected_keystore_config(
+    keystore_in_memory: bool,
+    configured: KeystoreConfig,
+) -> KeystoreConfig {
+    if keystore_in_memory {
+        KeystoreConfig::InMemory
+    } else {
+        configured
+    }
+}
+
+fn apply_keystore_config(mut config: Configuration, keystore_in_memory: bool) -> Configuration {
+    config.keystore = selected_keystore_config(keystore_in_memory, config.keystore);
+    config
+}
 
 impl SubstrateCli for Cli {
     fn impl_name() -> String {
@@ -223,6 +243,8 @@ pub fn run() -> sc_cli::Result<()> {
         None => {
             let runner = cli.create_runner(&cli.run)?;
             runner.run_node_until_exit(|config| async move {
+                let config = apply_keystore_config(config, cli.keystore_in_memory);
+
                 match config.network.network_backend {
                     sc_network::config::NetworkBackendType::Libp2p => {
                         service::new_full::<sc_network::NetworkWorker<_, _>>(
@@ -245,5 +267,36 @@ pub fn run() -> sc_cli::Result<()> {
                 }
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn selected_keystore_config_preserves_configured_keystore_by_default() {
+        let configured = KeystoreConfig::Path {
+            path: PathBuf::from("/tmp/torus-keystore"),
+            password: None,
+        };
+
+        let selected = selected_keystore_config(false, configured);
+
+        assert!(matches!(selected, KeystoreConfig::Path { .. }));
+    }
+
+    #[test]
+    fn selected_keystore_config_uses_in_memory_when_requested() {
+        let configured = KeystoreConfig::Path {
+            path: PathBuf::from("/tmp/torus-keystore"),
+            password: None,
+        };
+
+        let selected = selected_keystore_config(true, configured);
+
+        assert!(matches!(selected, KeystoreConfig::InMemory));
+        assert!(selected.path().is_none());
     }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `--keystore-in-memory` flag for hardened validator deployments. When set, the node overrides the generated service configuration to use Substrate's existing `KeystoreConfig::InMemory`, so session keys are not loaded from or written to an on-disk keystore path.

## Details

- Adds the top-level `--keystore-in-memory` CLI flag.
- Rejects conflicting key-loading or disk-backed options such as `--keystore-path`, password flags, `--dev`, and development key shortcuts.
- Applies the in-memory keystore selection before `service::new_full` constructs the node service.
- Covers CLI parsing and keystore selection with unit tests.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `WASM_BUILD_WORKSPACE_HINT=/Users/janzimolka/workspace/torus-substrate cargo test --target-dir /private/tmp/torus-target-issue155 -p torus-node keystore --locked`
- `WASM_BUILD_WORKSPACE_HINT=/Users/janzimolka/workspace/torus-substrate cargo clippy --target-dir /private/tmp/torus-target-issue155 -p torus-node --locked --all-targets -- -D warnings`
- Built `torus-node` and smoke-tested a fresh base path; no `keystore/` directory was created before the sandbox blocked network socket binding.

Closes #155.